### PR TITLE
fix: Detecting workspace ts path

### DIFF
--- a/src/features/tsVersion.ts
+++ b/src/features/tsVersion.ts
@@ -1,4 +1,4 @@
-import { ExtensionContext, workspace } from 'coc.nvim';
+import { ExtensionContext, Uri, workspace } from 'coc.nvim';
 import path from 'path';
 import * as shared from '@volar/shared';
 
@@ -26,7 +26,10 @@ function getWorkspaceTsPaths(useDefault = false) {
     tsdk = defaultTsdk;
   }
   if (tsdk) {
-    const tsPath = shared.getWorkspaceTypescriptPath(tsdk, workspace.workspaceFolders.map(folder => folder.uri));
+    const tsPath = shared.getWorkspaceTypescriptPath(
+      tsdk,
+      workspace.workspaceFolders.map((folder) => Uri.parse(folder.uri).fsPath)
+    );
     if (tsPath) {
       return {
         serverPath: tsPath,


### PR DESCRIPTION
## Description

Failed to detect tsLibs in the workspace.

**Setting (coc-settings.json)**:

```jsonc
{
  // ...snip
  "volar.useWorkspaceTsdk": true,
  // ...snip
}
```

Apply coc's fixes.

## Before

> Logging on ("volar-api.trace.server": "verbose")

![coc-volar-workspace-ts-01-before](https://user-images.githubusercontent.com/188642/128648280-fbb833d1-12a6-4668-9a5a-246359f3d6fe.gif)

## After

> Logging on ("volar-api.trace.server": "verbose")

![coc-volar-workspace-ts-02-after](https://user-images.githubusercontent.com/188642/128648290-9dcade5d-017f-41b5-b8b2-edb9c9c01597.gif)

