### PR TITLE
feat: Add "volar.dev.serverPath" option

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,11 @@
           "default": true,
           "description": "Enable coc-volar extension."
         },
+        "volar.dev.serverPath": {
+          "type": "string",
+          "default": "",
+          "description": "Absolute path to volar server module (For develop and check)"
+        },
         "volar.useWorkspaceTsdk": {
           "type": "boolean",
           "default": false,


### PR DESCRIPTION
Like vetur's `vetur.dev.vlsPath`.

**e.g. settings**:

```jsonc
{
  // ...snip
  // Absolute path
  "volar.dev.serverPath": "/Users/yaegassy/.local/src/volar/packages/server/out/index.js",
  // ...snip
}
```