### PR TITLE
feat: Add "volar.autoCompleteRefs" option

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,11 @@
           "default": true,
           "description": "[ref sugar ☐] code lens."
         },
+        "volar.autoCompleteRefs": {
+          "type": "boolean",
+          "default": false,
+          "description": "Auto-complete Ref value with '.value'."
+        },
         "volar.formatting.enable": {
           "type": "boolean",
           "default": true,

--- a/src/features/refComplete.ts
+++ b/src/features/refComplete.ts
@@ -1,0 +1,146 @@
+import * as coc from 'coc.nvim';
+import { workspace, snippetManager } from 'coc.nvim';
+import {
+  TextDocument,
+  TextDocumentPositionParams,
+  Position,
+  TextDocumentContentChangeEvent,
+  Range,
+} from 'vscode-languageserver-protocol';
+
+export async function activate(context: coc.ExtensionContext, tsClient: coc.LanguageClient) {
+  await tsClient.onReady();
+
+  context.subscriptions.push(
+    activateTagClosing(
+      (document: coc.TextDocument, position: coc.Position) => {
+        const param: TextDocumentPositionParams = {
+          textDocument: { uri: document.uri },
+          position,
+        };
+        return tsClient.sendRequest<string>('volar/ref', param);
+      },
+      {
+        vue: true,
+        javascript: true,
+        typescript: true,
+        javascriptreact: true,
+        typescriptreact: true,
+      },
+      'volar.autoCompleteRefs'
+    )
+  );
+}
+
+export function activateTagClosing(
+  tagProvider: (document: TextDocument, position: Position) => Thenable<string>,
+  supportedLanguages: { [id: string]: boolean },
+  configName: string
+): coc.Disposable {
+  let disposables: coc.Disposable[] = [];
+
+  workspace.onDidChangeTextDocument(
+    (event) => {
+      const editor = workspace.getDocument(event.textDocument.uri);
+      if (editor) {
+        onDidChangeTextDocument(editor.textDocument, event.contentChanges);
+      }
+    },
+    null,
+    disposables
+  );
+
+  let isEnabled = false;
+  updateEnabledState();
+
+  disposables.push(
+    workspace.registerAutocmd({
+      event: ['BufEnter'],
+      request: false,
+      callback: updateEnabledState,
+    })
+  );
+
+  let timeout: NodeJS.Timer | undefined = undefined;
+
+  async function updateEnabledState(): Promise<void> {
+    isEnabled = false;
+    const doc = await workspace.document;
+    if (!doc) {
+      return;
+    }
+    const document = doc.textDocument;
+    if (!supportedLanguages[document.languageId]) {
+      return;
+    }
+
+    if (!workspace.getConfiguration(undefined, document.uri).get<boolean>(configName)) {
+      return;
+    }
+    isEnabled = true;
+  }
+
+  async function onDidChangeTextDocument(
+    document: TextDocument,
+    changes: readonly TextDocumentContentChangeEvent[]
+  ): Promise<void> {
+    if (!isEnabled) {
+      return;
+    }
+    const doc = await workspace.document;
+    if (!doc) {
+      return;
+    }
+    const activeDocument = doc.textDocument;
+    if (document.uri !== activeDocument.uri || changes.length === 0) {
+      return;
+    }
+    if (typeof timeout !== 'undefined') {
+      clearTimeout(timeout);
+    }
+    const lastChange = changes[changes.length - 1];
+    if (!Range.is(lastChange['range']) || !lastChange.text) {
+      return;
+    }
+    const lastCharacter = lastChange.text[lastChange.text.length - 1];
+    if (lastCharacter === undefined) {
+      // delete text
+      return;
+    }
+    if (lastChange.text.indexOf('\n') >= 0) {
+      // multi-line change
+      return;
+    }
+
+    const rangeStart =
+      'range' in lastChange ? lastChange.range.start : coc.Position.create(0, document.getText().length);
+    const version = document.version;
+
+    timeout = setTimeout(async () => {
+      const position = Position.create(rangeStart.line, rangeStart.character + lastChange.text.length);
+      await tagProvider(document, position).then(async (text) => {
+        if (text && isEnabled) {
+          const doc = await workspace.document;
+          if (!doc) {
+            return;
+          }
+          const activeDocument = doc.textDocument;
+          if (document.uri === activeDocument.uri && activeDocument.version === version) {
+            // MEMO: select true
+            snippetManager.insertSnippet(text, true, Range.create(position, position)).catch(() => {
+              // noop
+            });
+          }
+        }
+      });
+      timeout = undefined;
+    }, 100);
+  }
+
+  return coc.Disposable.create(() => {
+    disposables.forEach((disposable) => {
+      disposable.dispose();
+    });
+    disposables = [];
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import * as documentVersion from './features/documentVersion';
 import * as documentPrintWidth from './features/documentPrintWidth';
 import * as showReferences from './features/showReferences';
 import * as tagClosing from './features/tagClosing';
+import * as refComplete from './features/refComplete';
 import * as tsVersion from './features/tsVersion';
 import * as verifyAll from './features/verifyAll';
 
@@ -66,6 +67,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   verifyAll.activate(context, docClient);
   tagClosing.activate(context, htmlClient);
+  refComplete.activate(context, apiClient);
 
   async function registarRestartRequest() {
     await Promise.all(clients.map((client) => client.onReady()));


### PR DESCRIPTION
## Description

"autoCompleteRefs" has been implemented in the `refComplete.ts` file. (port, `tagClosing.ts`)

## DEMO

> **coc-settings.json**:
> volar.autoCompleteRefs: true (default false)

![coc-volar-autoCompleteRefs](https://user-images.githubusercontent.com/188642/129481278-e8955d09-8201-4674-a960-6e4b28d0b8e8.gif)

## Misc

In coc-volar, `volar.autoCompleteRefs` is set to `false` by default.