### PR TITLE
feat: Add "volar.action.splitEditors" commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Plug 'yaegassy/coc-volar', {'do': 'yarn install --frozen-lockfile'}
 
 - `volar.action.restartServer`: Restart Vue server
 - `volar.action.verifyAllScripts`: Verify All Scripts
+- `volar.action.splitEditors`: Split `<script>`, `<template>`, `<style>` Editors
 
 ## Code Actions
 

--- a/package.json
+++ b/package.json
@@ -201,6 +201,11 @@
         "command": "volar.action.verifyAllScripts",
         "title": "Verify All Scripts",
         "category": "Volar"
+      },
+      {
+        "command": "volar.action.splitEditors",
+        "title": "Split <script>, <template>, <style> Editors",
+        "category": "Volar"
       }
     ]
   },

--- a/src/features/splitEditors.ts
+++ b/src/features/splitEditors.ts
@@ -1,0 +1,153 @@
+import { commands, ExtensionContext, Position, workspace, Document } from 'coc.nvim';
+
+export function activate(context: ExtensionContext) {
+  context.subscriptions.push(commands.registerCommand('volar.action.splitEditors', onSplit));
+
+  async function onSplit() {
+    const doc = await workspace.document;
+    if (!doc) {
+      return;
+    }
+
+    let countSFCBlock = 0;
+    const scriptTagRange = getTagRange(doc, 'script');
+    if (scriptTagRange) countSFCBlock++;
+    const templateTagRange = getTagRange(doc, 'template');
+    if (templateTagRange) countSFCBlock++;
+    const styleTagRange = getTagRange(doc, 'style');
+    if (styleTagRange) countSFCBlock++;
+
+    //
+    // MEMO: Full SFC
+    //
+    if (scriptTagRange && templateTagRange && styleTagRange && countSFCBlock === 3) {
+      /** 1 */
+      await workspace.jumpTo(doc.textDocument.uri, Position.create(scriptTagRange.start, scriptTagRange.end));
+      // folding
+      await workspace.nvim.command(`${templateTagRange.start + 1},${templateTagRange.end + 1}fold`);
+      await workspace.nvim.command(`${styleTagRange.start + 1},${styleTagRange.end + 1}fold`);
+
+      // Vertical split & Open all folds
+      await workspace.nvim.command('belowright vsplit || 1,$foldopen');
+
+      /** 2 */
+      await workspace.jumpTo(doc.textDocument.uri, Position.create(templateTagRange.start, templateTagRange.end));
+      // folding
+      await workspace.nvim.command(`${scriptTagRange.start + 1},${scriptTagRange.end + 1}fold`);
+      await workspace.nvim.command(`${styleTagRange.start + 1},${styleTagRange.end + 1}fold`);
+
+      // Split & Open all folds
+      await workspace.nvim.command('belowright split || 1,$foldopen');
+
+      /** 3 */
+      await workspace.jumpTo(doc.textDocument.uri, Position.create(styleTagRange.start, styleTagRange.end));
+      // folding
+      await workspace.nvim.command(`${scriptTagRange.start + 1},${scriptTagRange.end + 1}fold`);
+      await workspace.nvim.command(`${templateTagRange.start + 1},${templateTagRange.end + 1}fold`);
+    }
+
+    //
+    // MEMO: Two SFC
+    //
+    if (countSFCBlock == 2) {
+      if (scriptTagRange) {
+        /** 1 */
+        await workspace.jumpTo(doc.textDocument.uri, Position.create(scriptTagRange.start, scriptTagRange.end));
+
+        if (templateTagRange) {
+          // folding
+          await workspace.nvim.command(`${templateTagRange.start + 1},${templateTagRange.end + 1}fold`);
+        }
+        if (styleTagRange) {
+          // folding
+          await workspace.nvim.command(`${styleTagRange.start + 1},${styleTagRange.end + 1}fold`);
+        }
+
+        // Vertical split & Open all folds
+        await workspace.nvim.command('belowright vsplit || 1,$foldopen');
+
+        /** 2 */
+        if (templateTagRange) {
+          await workspace.jumpTo(doc.textDocument.uri, Position.create(templateTagRange.start, templateTagRange.end));
+          if (scriptTagRange) {
+            // folding
+            await workspace.nvim.command(`${scriptTagRange.start + 1},${scriptTagRange.end + 1}fold`);
+          }
+          if (styleTagRange) {
+            // folding
+            await workspace.nvim.command(`${styleTagRange.start + 1},${styleTagRange.end + 1}fold`);
+          }
+        } else if (styleTagRange) {
+          await workspace.jumpTo(doc.textDocument.uri, Position.create(styleTagRange.start, styleTagRange.end));
+          if (scriptTagRange) {
+            // folding
+            await workspace.nvim.command(`${scriptTagRange.start + 1},${scriptTagRange.end + 1}fold`);
+          }
+        }
+      } else if (templateTagRange) {
+        /** 1 */
+        await workspace.jumpTo(doc.textDocument.uri, Position.create(templateTagRange.start, templateTagRange.end));
+
+        if (styleTagRange) {
+          // folding
+          await workspace.nvim.command(`${styleTagRange.start + 1},${styleTagRange.end + 1}fold`);
+        }
+
+        // Vertical split & Open all folds
+        await workspace.nvim.command('belowright vsplit || 1,$foldopen');
+
+        /** 2 */
+        if (styleTagRange) {
+          await workspace.jumpTo(doc.textDocument.uri, Position.create(styleTagRange.start, styleTagRange.end));
+          // folding
+          await workspace.nvim.command(`${templateTagRange.start + 1},${templateTagRange.end + 1}fold`);
+        }
+      }
+    }
+  }
+}
+
+function getTagRange(doc: Document, tagType: 'script' | 'template' | 'style') {
+  let startRegex: RegExp;
+  let endRegex: RegExp;
+
+  if (tagType === 'script') {
+    startRegex = /^<script/;
+    endRegex = /^<\/script>/;
+  } else if (tagType === 'template') {
+    startRegex = /^<template/;
+    endRegex = /^<\/template>/;
+  } else if (tagType === 'style') {
+    startRegex = /^<style/;
+    endRegex = /^<\/style>/;
+  } else {
+    return;
+  }
+
+  const start = getTagLine(doc, startRegex);
+  const end = getTagLine(doc, endRegex);
+
+  if (start !== undefined && end !== undefined) {
+    return {
+      start,
+      end,
+    };
+  }
+
+  return;
+}
+
+function getTagLine(doc: Document, regex: RegExp): number | undefined {
+  let matchLine: number | undefined;
+
+  const text = doc.textDocument.getText();
+  const textArr = text.split('\n');
+  textArr.some((line, index) => {
+    if (line.match(regex)) {
+      matchLine = index;
+      return true;
+    }
+  });
+
+  return matchLine;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import * as documentPrintWidth from './features/documentPrintWidth';
 import * as showReferences from './features/showReferences';
 import * as tagClosing from './features/tagClosing';
 import * as refComplete from './features/refComplete';
+import * as splitEditors from './features/splitEditors';
 import * as tsVersion from './features/tsVersion';
 import * as verifyAll from './features/verifyAll';
 
@@ -65,6 +66,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   registarRestartRequest();
   registarClientRequests();
 
+  splitEditors.activate(context);
   verifyAll.activate(context, docClient);
   tagClosing.activate(context, htmlClient);
   refComplete.activate(context, apiClient);


### PR DESCRIPTION
## Description

Implemented using Vim's `split`, `vsplit` (vertical split), and `fold` related features.

## DEMO

### Full SFC tag block

![coc-volar-split-editor-1](https://user-images.githubusercontent.com/188642/129513898-244ffa2c-57d2-432f-bfd1-577e400bc1bc.gif)

### Two SFC tag block

![coc-volar-split-editor-2](https://user-images.githubusercontent.com/188642/129513910-55a89930-9754-4671-9a66-b228c05bc452.gif)
