### PR TITLE
chore: Add "vetur.enable" option (for coc-vetur)

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,6 +188,11 @@
           ],
           "default": "kebab",
           "description": "Attr name case."
+        },
+        "vetur.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable coc-vetur extension."
         }
       }
     },


### PR DESCRIPTION
Add the `vetur.enable` setting in "coc-volar" until this PR is merged. https://github.com/neoclide/coc-vetur/pull/76