### PR TITLE
feat: Add "volar.diagnostics.enable" option (Of course, default is true)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Please update vue-tsc by referring to this.
 
 - `volar.enable`: Enable coc-volar extension, default: `true`
 - `volar.useWorkspaceTsdk`: Use workspace (project) detected tsLibs in volar. if false, use coc-volar's built-in tsLibs, default: `false`
+- `volar.diagnostics.enable`: Enable/disable the Volar diagnostics, default: `true`
 - `volar.diagnostics.tsLocale`: Locale of diagnostics messages from typescript, valid option: `["cs", "de", "es", "fr", "it", "ja", "ko", "en", "pl", "pt-br", "ru", "tr", "zh-cn", "zh-tw"]`, default: `"en"`
 - `volar-api.trace.server`: Traces the communication between VS Code and the language server, valid option: `["off", "messages", "verbose"]`, default: `"off"`
 - `volar-document.trace.server`: Traces the communication between VS Code and the language server, valid option: `["off", "messages", "verbose"]`, default: `"off"`

--- a/package.json
+++ b/package.json
@@ -72,6 +72,11 @@
           "default": false,
           "description": "Use workspace (project) detected tsLibs in volar. if false, use coc-volar's built-in tsLibs."
         },
+        "volar.diagnostics.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable/disable the Volar diagnostics."
+        },
         "volar.diagnostics.tsLocale": {
           "type": "string",
           "enum": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,7 +169,7 @@ function createLanguageService(
             documentLink: true,
             codeLens: { showReferencesNotification: true },
             semanticTokens: true,
-            diagnostics: { getDocumentVersionRequest: true },
+            diagnostics: getConfigDiagnostics(),
             schemaRequestService: true,
           }
         : undefined,
@@ -226,6 +226,20 @@ function getConfigAttrNameCase() {
       return 'camelCase' as const;
   }
   return 'kebabCase' as const;
+}
+
+type DocumentDiagnosticsType = {
+  getDocumentVersionRequest: boolean;
+};
+
+function getConfigDiagnostics(): DocumentDiagnosticsType | undefined {
+  const isDiagnosticsEnable = workspace.getConfiguration('volar').get<boolean>('diagnostics.enable', true);
+
+  if (isDiagnosticsEnable) {
+    return { getDocumentVersionRequest: true };
+  } else {
+    return undefined;
+  }
 }
 
 type DocumentFormattingType = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,11 +228,7 @@ function getConfigAttrNameCase() {
   return 'kebabCase' as const;
 }
 
-type DocumentDiagnosticsType = {
-  getDocumentVersionRequest: boolean;
-};
-
-function getConfigDiagnostics(): DocumentDiagnosticsType | undefined {
+function getConfigDiagnostics(): NonNullable<shared.ServerInitializationOptions['languageFeatures']>['diagnostics'] {
   const isDiagnosticsEnable = workspace.getConfiguration('volar').get<boolean>('diagnostics.enable', true);
 
   if (isDiagnosticsEnable) {


### PR DESCRIPTION
## Description

Volar's linting (diagsnotics) is a "core feature", it would be a very, very shame to disable it.

However, some users want to use only eslint (+eslint-plugin-vue).

Add a configuration option to enable/disable diagnostics. (Of course, default is `true`)