### PR TITLE
fix: Adjust css completion results with middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,6 +199,11 @@
           "default": "kebab",
           "description": "Attr name case."
         },
+        "volar.fix.completion": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable fix patch for `css` completion issue"
+        },
         "vetur.enable": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
## Description

Close https://github.com/yaegassy/coc-volar/issues/38

- Use middleware to fix completion results.
- Add `volar.fix.completion` option (default is `true`)
  - This is an option in the fix patch, so I won't add it to the README.

## DEMO (OK)

https://user-images.githubusercontent.com/188642/131160157-c29f64eb-5d05-4ed5-bfca-a3e520b8b154.mp4
