### PR TITLE
feat: Add "volar.doctor" command (show infomation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Please update vue-tsc by referring to this.
 ## Commands
 
 - `volar.version`: Show Volar (client/server) version
+- `volar.doctor`: Show Doctor info
 - `volar.action.restartServer`: Restart Vue server
 - `volar.action.verifyAllScripts`: Verify All Scripts
 - `volar.action.splitEditors`: Split `<script>`, `<template>`, `<style>` Editors

--- a/package.json
+++ b/package.json
@@ -223,6 +223,11 @@
         "category": "Volar"
       },
       {
+        "command": "volar.doctor",
+        "title": "Show Doctor info",
+        "category": "Volar"
+      },
+      {
         "command": "volar.action.restartServer",
         "title": "Restart Vue server",
         "category": "Volar"

--- a/src/client/commands.ts
+++ b/src/client/commands.ts
@@ -9,3 +9,108 @@ export function versionCommand(context: ExtensionContext) {
   const serverPackage = JSON.parse(fs.readFileSync(serverJSON, 'utf8'));
   window.showMessage(`coc-volar(client) v${clientPackage.version} with volar(server) v${serverPackage.version}`);
 }
+
+export function doctorCommand(context: ExtensionContext) {
+  return async () => {
+    const { document } = await workspace.getCurrentState();
+    const fileName = path.basename(document.uri);
+
+    if (!fileName.endsWith('.vue')) {
+      return window.showInformationMessage('Failed to doctor. Make sure the current file is a .vue file.');
+    }
+
+    const clientJSON = path.join(context.extensionPath, 'package.json');
+    const clientPackage = JSON.parse(fs.readFileSync(clientJSON, 'utf8'));
+    const serverJSON = path.join(context.extensionPath, 'node_modules', '@volar', 'server', 'package.json');
+    const serverPackage = JSON.parse(fs.readFileSync(serverJSON, 'utf8'));
+
+    let vueVersion: string | undefined;
+    let vueRuntimeDomVersion: string | undefined;
+    let vueTscDepVersion: string | undefined;
+    let vueTscExtVersion: string | undefined;
+
+    if (workspace.workspaceFolders) {
+      for (const folder of workspace.workspaceFolders) {
+        const vuePackageJsonPath = path.join(Uri.parse(folder.uri).fsPath, 'node_modules', 'vue', 'package.json');
+
+        const vueRuntimeDomPackageJsonPath = path.join(
+          Uri.parse(folder.uri).fsPath,
+          'node_modules',
+          '@vue',
+          'runtime-dom',
+          'package.json'
+        );
+
+        const vueTscDepPackageJsonPath = path.join(
+          Uri.parse(folder.uri).fsPath,
+          'node_modules',
+          'vscode-vue-languageservice',
+          'package.json'
+        );
+
+        const vueTscExtPackageJsonPath = path.join(
+          context.extensionPath,
+          'node_modules',
+          'vscode-vue-languageservice',
+          'package.json'
+        );
+
+        if (fs.existsSync(vuePackageJsonPath)) {
+          vueVersion = getPackageVersion(vuePackageJsonPath);
+        }
+
+        if (fs.existsSync(vueRuntimeDomPackageJsonPath)) {
+          vueRuntimeDomVersion = getPackageVersion(vueRuntimeDomPackageJsonPath);
+        }
+
+        if (fs.existsSync(vueTscDepPackageJsonPath)) {
+          vueTscDepVersion = getPackageVersion(vueTscDepPackageJsonPath);
+        }
+
+        if (fs.existsSync(vueTscExtPackageJsonPath)) {
+          vueTscExtVersion = getPackageVersion(vueTscExtPackageJsonPath);
+        }
+      }
+    }
+
+    let tsVersion: string | undefined;
+    const tsServerPath = context.workspaceState.get<string>('coc-volar-ts-server-path');
+    if (tsServerPath) {
+      const typescriptPackageJsonPath = path.join(path.resolve(path.dirname(tsServerPath), '..'), 'package.json');
+      if (fs.existsSync(typescriptPackageJsonPath)) {
+        tsVersion = getPackageVersion(typescriptPackageJsonPath);
+      }
+    }
+
+    const doctorData = {
+      title: '---- Volar doctor ----',
+      clientVersion: clientPackage.version,
+      serverVersion: serverPackage.version,
+      vueVersion: vueVersion === undefined ? 'none' : vueVersion,
+      vueRuntimeDomVersion: vueRuntimeDomVersion === undefined ? 'none' : vueRuntimeDomVersion,
+      vueTscDepVersion: vueTscDepVersion === undefined ? 'none' : vueTscDepVersion,
+      vueTscExtVersion: vueTscExtVersion,
+      tsVersion,
+      tsServerPath,
+    };
+
+    const outputText = JSON.stringify(doctorData, null, 2);
+
+    await workspace.nvim
+      .command('belowright vnew volar-doctor | setlocal buftype=nofile bufhidden=hide noswapfile filetype=json')
+      .then(async () => {
+        const buf = await workspace.nvim.buffer;
+        buf.setLines(outputText.split('\n'), { start: 0, end: -1 });
+      });
+  };
+}
+
+function getPackageVersion(packageJsonPath: string): string | undefined {
+  let version: string | undefined;
+  try {
+    const packageJsonText = fs.readFileSync(packageJsonPath, 'utf8');
+    const packageJson = JSON.parse(packageJsonText);
+    version = packageJson.version;
+  } catch {}
+  return version;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ import * as verifyAll from './features/verifyAll';
 import * as vueTscVersion from './features/vueTscVersion';
 
 import { VolarCodeActionProvider } from './client/actions';
-import { versionCommand } from './client/commands';
+import { doctorCommand, versionCommand } from './client/commands';
 
 let apiClient: LanguageClient;
 let docClient: LanguageClient | undefined;
@@ -58,6 +58,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   if (!isEnable) return;
 
   outputChannel.appendLine(`${'#'.repeat(10)} volar-client\n`);
+  initializeWorkspaceState(context);
 
   const devVolarServerPath = extensionConfig.get<string>('dev.serverPath', '');
   if (devVolarServerPath && devVolarServerPath !== '' && fs.existsSync(devVolarServerPath)) {
@@ -117,6 +118,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   /** MEMO: for coc-volar */
   context.subscriptions.push(commands.registerCommand('volar.version', () => versionCommand(context)));
+  context.subscriptions.push(commands.registerCommand('volar.doctor', doctorCommand(context)));
 
   /** MEMO: for coc-volar */
   const languageSelector: DocumentSelector = [{ language: 'vue', scheme: 'file' }];
@@ -148,6 +150,7 @@ function createLanguageService(
 
   if (!resolveCurrentTsPaths) {
     resolveCurrentTsPaths = tsVersion.getCurrentTsPaths(context);
+    context.workspaceState.update('coc-volar-ts-server-path', resolveCurrentTsPaths.serverPath);
     outputChannel.appendLine(`currentTsPath: ${resolveCurrentTsPaths.serverPath}`);
     outputChannel.appendLine(`localizePath: ${resolveCurrentTsPaths.localizedPath}`);
     outputChannel.appendLine(`isWorkspacePath: ${resolveCurrentTsPaths.isWorkspacePath}`);
@@ -305,4 +308,8 @@ function getConfigDocumentFormatting(): NonNullable<
 
 function getConfigFixCompletion() {
   return workspace.getConfiguration('volar').get<boolean>('fix.completion', true);
+}
+
+function initializeWorkspaceState(context: ExtensionContext) {
+  context.workspaceState.update('coc-volar-ts-server-path', undefined);
 }


### PR DESCRIPTION
## Description

Created a command to output various version information that may be relevant to `volar`.

## DEMO[mp4] | vite (vue-ts)

https://user-images.githubusercontent.com/188642/132377473-bf668a3d-2dae-490e-b4df-c15e9067f783.mp4

## Screen Shot (PNG)

### e.g. vite (vue3, javascript)

<img width="1001" alt="coc-volar-doctor-2" src="https://user-images.githubusercontent.com/188642/132377692-4e22ec2e-4ae6-44a3-a0d5-f9000cafdf83.png">

### e.g. vue cli (vue2 javascript)

<img width="998" alt="coc-volar-doctor-3" src="https://user-images.githubusercontent.com/188642/132377723-e88dfea1-4f72-4297-bb63-922942e4af8f.png">
