### PR TITLE
feat: support for package version detection when using "pnpm"

### DIFF
--- a/src/features/vueTscVersion.ts
+++ b/src/features/vueTscVersion.ts
@@ -7,6 +7,11 @@ export async function activate(context: ExtensionContext) {
 
   if (workspace.workspaceFolders) {
     for (const folder of workspace.workspaceFolders) {
+      // MEMO: pnpm related
+      const pnpmPackagesDirNames = getDirectoryItemNames(
+        path.join(Uri.parse(folder.uri).fsPath, 'node_modules', '.pnpm')
+      );
+
       // MEMO: Uri.parse(folder.uri).fsPath for coc.nvim
       const vueTscVueLsPackageJsonPath = path.join(
         Uri.parse(folder.uri).fsPath,
@@ -22,35 +27,72 @@ export async function activate(context: ExtensionContext) {
         'package.json'
       );
 
-      if (fs.existsSync(vueTscVueLsPackageJsonPath) && fs.existsSync(extVueTscVueLsPackageJsonPath)) {
-        try {
+      try {
+        let vueTscVueLsVersion: string | undefined;
+        let extVueTscVueLsVersion: string | undefined;
+
+        // npm, yarn
+        if (fs.existsSync(vueTscVueLsPackageJsonPath)) {
           const vueTscVueLsPackageJsonText = fs.readFileSync(vueTscVueLsPackageJsonPath, 'utf8');
           const vueTscVueLsPackageJson = JSON.parse(vueTscVueLsPackageJsonText);
-          const vueTscVueLsVersion = vueTscVueLsPackageJson.version;
+          vueTscVueLsVersion = vueTscVueLsPackageJson.version;
+        }
+        // pnpm
+        if (!vueTscVueLsVersion) {
+          vueTscVueLsVersion = getPackageVersionFromDirectoryName(
+            pnpmPackagesDirNames,
+            /^vscode-vue-languageservice@.*$/
+          );
+        }
 
+        if (fs.existsSync(extVueTscVueLsPackageJsonPath)) {
           const extVueTscVueLsPackageJsonText = fs.readFileSync(extVueTscVueLsPackageJsonPath, 'utf8');
           const extVueTscVueLsPackageJson = JSON.parse(extVueTscVueLsPackageJsonText);
-          const extVueTscVueLsVersion = extVueTscVueLsPackageJson.version;
+          extVueTscVueLsVersion = extVueTscVueLsPackageJson.version;
+        }
 
-          if (vueTscVueLsVersion && vueTscVueLsVersion !== extVueTscVueLsVersion) {
-            const message = `vue-tsc's dependency version (${vueTscVueLsVersion}) is different to Extension version (${extVueTscVueLsVersion}). Type-checking behavior maybe different.`;
-            const howTo = 'How To Update?';
-            const disable = 'Disable Version Checking';
+        if (vueTscVueLsVersion && vueTscVueLsVersion !== extVueTscVueLsVersion) {
+          const message = `vue-tsc's dependency version (${vueTscVueLsVersion}) is different to Extension version (${extVueTscVueLsVersion}). Type-checking behavior maybe different.`;
+          const howTo = 'How To Update?';
+          const disable = 'Disable Version Checking';
 
-            const option = await window.showInformationMessage(message, howTo, disable);
+          const option = await window.showInformationMessage(message, howTo, disable);
 
-            if (option === howTo) {
-              // In coc-volar, use vscode.open
-              commands.executeCommand('vscode.open', ['https://github.com/johnsoncodehk/volar/discussions/402']);
-            }
-            if (option === disable) {
-              await workspace.nvim.command(`CocRestart`, true);
-              const config = workspace.getConfiguration('volar');
-              config.update('checkVueTscVersion', false);
-            }
+          if (option === howTo) {
+            // In coc-volar, use vscode.open
+            commands.executeCommand('vscode.open', ['https://github.com/johnsoncodehk/volar/discussions/402']);
           }
-        } catch {}
-      }
+          if (option === disable) {
+            await workspace.nvim.command(`CocRestart`, true);
+            const config = workspace.getConfiguration('volar');
+            config.update('checkVueTscVersion', false);
+          }
+        }
+      } catch {}
     }
   }
+}
+
+function getDirectoryItemNames(dirPath: string): string[] | undefined {
+  let a: string[] | undefined = [];
+  try {
+    a = fs.readdirSync(dirPath);
+  } catch {
+    return undefined;
+  }
+  return a;
+}
+
+function getPackageVersionFromDirectoryName(items: string[] | undefined, regex: RegExp) {
+  let r: string | undefined;
+  if (items) {
+    items.forEach((v) => {
+      const m = v.match(regex);
+      if (m) {
+        v = v.replace(/^@/, '');
+        r = v.split('@')[1];
+      }
+    });
+  }
+  return r;
 }


### PR DESCRIPTION
I don't use `pnpm`, but in the case of `pnpm`, I had to make adjustments to get the version of the dependent package

I checked with vue-tsc's `v0.3.0` and `v0.2.2` (deps: `vscode-vue-languageservice@0.26.16`).