### PR TITLE
chore: sync volar v0.28.4 ("activationEvents" will not change yet...)

### DIFF
--- a/package.json
+++ b/package.json
@@ -253,8 +253,8 @@
     ]
   },
   "dependencies": {
-    "@volar/server": "0.28.3",
-    "@volar/shared": "0.28.3",
+    "@volar/server": "0.28.4",
+    "@volar/shared": "0.28.4",
     "@vue/reactivity": "3.2.20",
     "typescript": "4.4.3",
     "vscode-html-languageservice": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -351,60 +351,60 @@
     "@typescript-eslint/types" "4.28.5"
     eslint-visitor-keys "^2.0.0"
 
-"@volar/code-gen@0.28.3":
-  version "0.28.3"
-  resolved "https://registry.yarnpkg.com/@volar/code-gen/-/code-gen-0.28.3.tgz#e39e8facc9561e6ac906d6f3a1bbe07e757adfc2"
-  integrity sha512-ydDIhR+vffbizWXWJGxjYpomWKMUH7uEWUpAhTxiCxYgZ3o/GKVYa2r1kXzBDq6M1zJyHtv6f/pM/GIUXzSfBg==
+"@volar/code-gen@0.28.4":
+  version "0.28.4"
+  resolved "https://registry.yarnpkg.com/@volar/code-gen/-/code-gen-0.28.4.tgz#a337fe46e745d6da5436c2bde5645b120803d65c"
+  integrity sha512-dLN1lPKEla7hIbhj1sFM1XUneKnjEciFahvpQRVENujAA/xakck5LqpNK1XGcfq+EVDPGR0LnVO6rq3KuOXg/A==
   dependencies:
-    "@volar/shared" "0.28.3"
-    "@volar/source-map" "0.28.3"
+    "@volar/shared" "0.28.4"
+    "@volar/source-map" "0.28.4"
 
-"@volar/html2pug@0.28.3":
-  version "0.28.3"
-  resolved "https://registry.yarnpkg.com/@volar/html2pug/-/html2pug-0.28.3.tgz#23c7ae51d303080d341c58033707d8b5ae89381b"
-  integrity sha512-4He/Dpajv6RRVSyHLaCOGPpiNR75wj5O2YaNAh2zAxPu8lTFUEDOZFxJALjlT0o1BbnfLwJ3zQTHIf1YCm6uIw==
+"@volar/html2pug@0.28.4":
+  version "0.28.4"
+  resolved "https://registry.yarnpkg.com/@volar/html2pug/-/html2pug-0.28.4.tgz#475acb831dc8d592737f25682e3e569ec6aae268"
+  integrity sha512-AMEL6WnmBwzvgBMcYIvwOsRkxIYoTevykozl59MIFlCRQ1o9zev+sanl73r1fbNyRSD+b1rBGhphmWLRQkpMFQ==
   dependencies:
     domelementtype "^2.2.0"
     domhandler "^4.2.2"
     htmlparser2 "^7.1.2"
     pug "^3.0.2"
 
-"@volar/server@0.28.3":
-  version "0.28.3"
-  resolved "https://registry.yarnpkg.com/@volar/server/-/server-0.28.3.tgz#dfc613e83261eb45f33411487e0fd5af9f0147da"
-  integrity sha512-lSiOtfjo0J4ovJOYKLUbQM8yMyFsEJ/StRiQU6asvcZgq7ggbdFcq2fftfo50OiNzrbMlsl+EqlDQ5wjNSIpmg==
+"@volar/server@0.28.4":
+  version "0.28.4"
+  resolved "https://registry.yarnpkg.com/@volar/server/-/server-0.28.4.tgz#ab1d52e2d0af8adf53c2b1d69cdf0f2dbe938045"
+  integrity sha512-9/udy4ZgbrouZU6/vYTVEcwvKm2uZvnL0OnTqNITi8Xklttc6drVGR+bIgVF+4I6mWAMpbGs2roaxCiOGVPdGg==
   dependencies:
     "@starptech/prettyhtml" "^0.10.0"
-    "@volar/shared" "0.28.3"
+    "@volar/shared" "0.28.4"
     prettier "^1.16.4"
     pug-beautify "^0.1.1"
     upath "^2.0.1"
     vscode-languageserver "^8.0.0-next.2"
     vscode-languageserver-textdocument "^1.0.1"
-    vscode-vue-languageservice "0.28.3"
+    vscode-vue-languageservice "0.28.4"
 
-"@volar/shared@0.28.3":
-  version "0.28.3"
-  resolved "https://registry.yarnpkg.com/@volar/shared/-/shared-0.28.3.tgz#82a202ef5e6a5df3ad9449e5823ce8fcd550ed69"
-  integrity sha512-e04arodpZ12qEYxtovVkMwtf5eJHrSgOIFtnQA20dXjcnX4Dx8xR7vZU2/gG882vTnlpMyBEOu7JIUe54qadbg==
+"@volar/shared@0.28.4":
+  version "0.28.4"
+  resolved "https://registry.yarnpkg.com/@volar/shared/-/shared-0.28.4.tgz#f7bd78e16a92f83e732967e3368886eef8e76a5d"
+  integrity sha512-fa/n4KoPjk5wD9PgsfYm7mzZkM9wLDFvr1Y6QEXhrJUlGKaA/TjbUPTNOOu52I239EWEP5yv4p/CLCgU4QvZxw==
   dependencies:
     upath "^2.0.1"
     vscode-jsonrpc "^8.0.0-next.2"
     vscode-uri "^3.0.2"
 
-"@volar/source-map@0.28.3":
-  version "0.28.3"
-  resolved "https://registry.yarnpkg.com/@volar/source-map/-/source-map-0.28.3.tgz#3ca22e2eae6195726f3d047232845d50884f9d87"
-  integrity sha512-owHCe36ofEug93K8PoyWqjDMUZtVGiXAnXl3eUh4Dlhxpe1yzjqS9MB3Ff9QnEyOL0FUCtpT2+s2UzZg9EMGhg==
+"@volar/source-map@0.28.4":
+  version "0.28.4"
+  resolved "https://registry.yarnpkg.com/@volar/source-map/-/source-map-0.28.4.tgz#3c955d276e58ddcc1b150249debcb1a1689f8892"
+  integrity sha512-v5PG0ltadMIcQiSD4E3quW8wTW9MP8sjf/amgZRtSJXBmJ21Pc6L4dBe32ygi4G8podlK0hOUr68e3anfSFfXg==
   dependencies:
-    "@volar/shared" "0.28.3"
+    "@volar/shared" "0.28.4"
 
-"@volar/transforms@0.28.3":
-  version "0.28.3"
-  resolved "https://registry.yarnpkg.com/@volar/transforms/-/transforms-0.28.3.tgz#76bef90aef49943ee45116ad6e73ff8e2f1faec7"
-  integrity sha512-htrX9Jp1HpEO+i5sajXI/cZKpLF8Cko/em2odhsDazBmn4GbTPDdbowJY4hUlAUgnbV1k9HeketNSXByveyBlg==
+"@volar/transforms@0.28.4":
+  version "0.28.4"
+  resolved "https://registry.yarnpkg.com/@volar/transforms/-/transforms-0.28.4.tgz#56f5b5817e0246fe4839505dedb96ec2f19d4365"
+  integrity sha512-T8uTMOdSQhhz4fFlxFbQ5AW31pzUXxurLdYJd6CcYU5jD2zU7bpJoeLRd45kWPfkMf3MuTLkpemqwfFAlP3eYQ==
   dependencies:
-    "@volar/shared" "0.28.3"
+    "@volar/shared" "0.28.4"
     vscode-languageserver "^8.0.0-next.2"
 
 "@vscode/emmet-helper@^2.8.0":
@@ -3087,25 +3087,25 @@ vscode-nls@^5.0.0:
   resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-5.0.0.tgz#99f0da0bd9ea7cda44e565a74c54b1f2bc257840"
   integrity sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA==
 
-vscode-pug-languageservice@0.28.3:
-  version "0.28.3"
-  resolved "https://registry.yarnpkg.com/vscode-pug-languageservice/-/vscode-pug-languageservice-0.28.3.tgz#4573e2d7a1acecae11a5e893dc768acb33e8a09f"
-  integrity sha512-lQSNAFZcFehqIkw6AzeTQoB/b6PEBQ1jc4yRYM7WVWZf+NH4TkHABrmKD5YOnsHNgP/LFV8T/aDXy/TUgUut+Q==
+vscode-pug-languageservice@0.28.4:
+  version "0.28.4"
+  resolved "https://registry.yarnpkg.com/vscode-pug-languageservice/-/vscode-pug-languageservice-0.28.4.tgz#9e58cb665c417d71121db8d28bb23052fe112b92"
+  integrity sha512-YpmYmJQQM2fnqukhcOBv51zv52p96T0fYgpCMS9DhMo303Oeacf+GFtsrNZCk3i1cGQXsrtoIKO7AK3r0uWwYg==
   dependencies:
-    "@volar/code-gen" "0.28.3"
-    "@volar/shared" "0.28.3"
-    "@volar/source-map" "0.28.3"
-    "@volar/transforms" "0.28.3"
+    "@volar/code-gen" "0.28.4"
+    "@volar/shared" "0.28.4"
+    "@volar/source-map" "0.28.4"
+    "@volar/transforms" "0.28.4"
     pug-lexer "^5.0.1"
     pug-parser "^6.0.0"
     vscode-languageserver "^8.0.0-next.2"
 
-vscode-typescript-languageservice@0.28.3:
-  version "0.28.3"
-  resolved "https://registry.yarnpkg.com/vscode-typescript-languageservice/-/vscode-typescript-languageservice-0.28.3.tgz#1eac8d442a6d3b53793194402d4759f56962ec7f"
-  integrity sha512-H9zRwECnMDJNiOmwL0/AZv/UeMWAyPr+9McxCd4KPsC+uMX9UMsVfb3AupoNG1Xoj386/U7g9SMcVOx3EI5UeQ==
+vscode-typescript-languageservice@0.28.4:
+  version "0.28.4"
+  resolved "https://registry.yarnpkg.com/vscode-typescript-languageservice/-/vscode-typescript-languageservice-0.28.4.tgz#1338e3d32607eeee76ba9b40e04186794286cbf3"
+  integrity sha512-STDoJ+Cu3N8/d5iLAPROhza4COumP8g8gfnY5eUZvk0mRjx8OegfiacAOTmwYCaJIRlIekfz6ktJrMnI4tznyg==
   dependencies:
-    "@volar/shared" "0.28.3"
+    "@volar/shared" "0.28.4"
     semver "^7.3.5"
     upath "^2.0.1"
     vscode-languageserver "^8.0.0-next.2"
@@ -3121,16 +3121,16 @@ vscode-uri@^3.0.2:
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.2.tgz#ecfd1d066cb8ef4c3a208decdbab9a8c23d055d0"
   integrity sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA==
 
-vscode-vue-languageservice@0.28.3:
-  version "0.28.3"
-  resolved "https://registry.yarnpkg.com/vscode-vue-languageservice/-/vscode-vue-languageservice-0.28.3.tgz#69f8c663694e8d0b2673452987b414572a5ab565"
-  integrity sha512-RHYu3IHM6RXgLKow+LSQocfWi3y9yVvdwo1QcuPWsoKWo3sSIVT1dP/HzRWjcOGzZ/58MmTGDlQsgZIK3/geAw==
+vscode-vue-languageservice@0.28.4:
+  version "0.28.4"
+  resolved "https://registry.yarnpkg.com/vscode-vue-languageservice/-/vscode-vue-languageservice-0.28.4.tgz#092fa4fe2267bcea2cc792b950123977af59b1e0"
+  integrity sha512-KgPGA/jMwjD/1v0FB+IMK/4Z+Qd/ymsAbQslhd3zaUfp8s4z9J9gbPTXz1USAfSXrgKoPeoie00+Ef32+mBt0w==
   dependencies:
-    "@volar/code-gen" "0.28.3"
-    "@volar/html2pug" "0.28.3"
-    "@volar/shared" "0.28.3"
-    "@volar/source-map" "0.28.3"
-    "@volar/transforms" "0.28.3"
+    "@volar/code-gen" "0.28.4"
+    "@volar/html2pug" "0.28.4"
+    "@volar/shared" "0.28.4"
+    "@volar/source-map" "0.28.4"
+    "@volar/transforms" "0.28.4"
     "@vscode/emmet-helper" "^2.8.0"
     "@vue/compiler-dom" "^3.2.20"
     "@vue/reactivity" "^3.2.20"
@@ -3142,8 +3142,8 @@ vscode-vue-languageservice@0.28.3:
     vscode-json-languageservice "^4.1.8"
     vscode-languageserver "^8.0.0-next.2"
     vscode-languageserver-textdocument "^1.0.1"
-    vscode-pug-languageservice "0.28.3"
-    vscode-typescript-languageservice "0.28.3"
+    vscode-pug-languageservice "0.28.4"
+    vscode-typescript-languageservice "0.28.4"
 
 which@^1.2.9:
   version "1.3.1"


### PR DESCRIPTION
Changes to activateEvents will be handled separately.

There are some considerations, such as when you open `*.ts`, `*.js`, etc... in a "non-Vue" project.

Also, if takeOverMode is enabled, `coc-tsserver` needs to be stopped