### PR TITLE
feat(command): add "volar.initializeTakeOverMode" commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,25 @@ Plug 'yaegassy/coc-volar', {'do': 'yarn install --frozen-lockfile'}
 - <https://github.com/johnsoncodehk/volar/tree/master/extensions/vscode-vue-language-features#using>
 - <https://github.com/johnsoncodehk/volar/tree/master/extensions/vscode-vue-language-features#note>
 
+## How to enable "TakeOverMode" in coc-volar
+
+### If you are using "TakeOverMode" for the first time in your project
+
+1. [Must] To begin, open the `*.vue` file. (Do not open the `*.ts` file first!)
+1. Then run `:CocCommand volar.initializeTakeOverMode`.
+1. When prompted by `Enable TakeOverMode? (y/n)?`, enter `y`
+1. The `.vim/coc-settings.json` file will be created in the "project root".
+   - The `"volar.takeOverMode.enabled": true` and `"tsserver.enable": false` settings will be added.
+1. `coc.nvim` will be restarted and the settings will be reflected.
+
+### If the project already has "TakeOverMode" enabled
+
+1. [Must] To begin, open the `*.vue` file. (Do not open the `*.ts` file first!)
+
+### If you want to disable TakeOverMode for a project
+
+Delete the `.vim/coc-settings.json` file in the "project root", and start Vim again.
+
 ## Configuration options
 
 - `volar.enable`: Enable coc-volar extension, default: `true`
@@ -64,6 +83,7 @@ Plug 'yaegassy/coc-volar', {'do': 'yarn install --frozen-lockfile'}
 - `volar.doctor`: Show Doctor info
   - You can check the versions and settings of various packages
     - client, server, vue, @vue/runtime-dom, vue-tsc, typescript related, coc-volar's configuration, and more...
+- `volar.initializeTakeOverMode`: Enable TakeOverMode in your project
 - `volar.action.restartServer`: Restart Vue server
 - `volar.action.verifyAllScripts`: Verify All Scripts
 - `volar.action.splitEditors`: Split `<script>`, `<template>`, `<style>` Editors

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "rimraf": "^3.0.2"
   },
   "activationEvents": [
-    "onLanguage:vue"
+    "onLanguage:vue",
+    "onCommand:volar.initializeTakeOverMode"
   ],
   "contributes": {
     "configuration": {
@@ -233,6 +234,11 @@
       {
         "command": "volar.doctor",
         "title": "Show Doctor info",
+        "category": "Volar"
+      },
+      {
+        "command": "volar.initializeTakeOverMode",
+        "title": "Enable TakeOverMode in your project",
         "category": "Volar"
       },
       {

--- a/src/client/commands.ts
+++ b/src/client/commands.ts
@@ -95,6 +95,24 @@ export function doctorCommand(context: ExtensionContext) {
   };
 }
 
+export function initializeTakeOverModeCommand() {
+  return async () => {
+    const enableTakeOverMode = await window.showPrompt('Enable TakeOverMode?');
+    const config = workspace.getConfiguration('volar');
+    const tsserverConfig = workspace.getConfiguration('tsserver');
+
+    if (enableTakeOverMode) {
+      config.update('takeOverMode.enabled', true);
+      tsserverConfig.update('enable', false);
+    } else {
+      config.update('takeOverMode.enabled', false);
+      tsserverConfig.update('enable', true);
+    }
+
+    workspace.nvim.command(`CocRestart`, true);
+  };
+}
+
 function getPackageVersionFromJson(packageJsonPath: string): string | undefined {
   let version: string | undefined;
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ import * as tsVersion from './features/tsVersion';
 import * as verifyAll from './features/verifyAll';
 
 import { VolarCodeActionProvider } from './client/actions';
-import { doctorCommand } from './client/commands';
+import { doctorCommand, initializeTakeOverModeCommand } from './client/commands';
 
 let apiClient: LanguageClient;
 let docClient: LanguageClient | undefined;
@@ -68,6 +68,9 @@ export async function activate(context: ExtensionContext): Promise<void> {
   } else {
     serverModule = context.asAbsolutePath(path.join('node_modules', '@volar', 'server', 'out', 'index.js'));
   }
+
+  /** MEMO: Custom commands for coc-volar */
+  context.subscriptions.push(commands.registerCommand('volar.initializeTakeOverMode', initializeTakeOverModeCommand()));
 
   lowPowerMode = lowPowerModeEnabled();
   const takeOverMode = takeOverModeEnabled();
@@ -142,10 +145,10 @@ export async function activate(context: ExtensionContext): Promise<void> {
     }
   }
 
-  /** MEMO: for coc-volar */
+  /** MEMO: Custom commands for coc-volar */
   context.subscriptions.push(commands.registerCommand('volar.doctor', doctorCommand(context)));
 
-  /** MEMO: for coc-volar */
+  /** MEMO: Custom action for coc-volar */
   const languageSelector: DocumentSelector = [{ language: 'vue', scheme: 'file' }];
   const codeActionProvider = new VolarCodeActionProvider();
   context.subscriptions.push(languages.registerCodeActionProvider(languageSelector, codeActionProvider, 'volar'));


### PR DESCRIPTION
## Description

"activationEvents" has been added to volar (upstream)

- <https://github.com/johnsoncodehk/volar/commit/eda4612d92cf3d5961343ae0f142050a3dd7a21b>
- <https://github.com/johnsoncodehk/volar/discussions/471#discussioncomment-1458211>

We wanted to avoid adding `activationEvents` in the same way in coc-volar, if possible, because it may cause problems for other extensions.

First, I would like to add a dedicated command and documentation to see how it goes.

It also solves this problem. Close https://github.com/yaegassy/coc-volar/issues/83

## DEMO (mp4)

https://user-images.githubusercontent.com/188642/137449773-16bc049e-1ac6-4990-969d-7b97867b7f59.mp4

### Idea

- REF: [vscode_deno](https://github.com/denoland/vscode_deno)
  - `deno.initializeWorkspace` command
  -  <https://github.com/denoland/vscode_deno#usage>