### PR TITLE
chore: sync volar v0.28.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -259,8 +259,8 @@
     ]
   },
   "dependencies": {
-    "@volar/server": "0.28.8",
-    "@volar/shared": "0.28.8",
+    "@volar/server": "0.28.9",
+    "@volar/shared": "0.28.9",
     "@vue/reactivity": "3.2.20",
     "typescript": "4.4.3",
     "vscode-html-languageservice": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -351,60 +351,60 @@
     "@typescript-eslint/types" "4.28.5"
     eslint-visitor-keys "^2.0.0"
 
-"@volar/code-gen@0.28.8":
-  version "0.28.8"
-  resolved "https://registry.yarnpkg.com/@volar/code-gen/-/code-gen-0.28.8.tgz#6675c261317ef10cb56d4ccaadb50dc04c862548"
-  integrity sha512-zoU+qz5Txx2HNWxDp0ACxOj2/fSFvqKaj9spAuqSQbZvrf+FWN8cnuod/JCBRhHnvb4ie9Z/NLkMid6Hfxirag==
+"@volar/code-gen@0.28.9":
+  version "0.28.9"
+  resolved "https://registry.yarnpkg.com/@volar/code-gen/-/code-gen-0.28.9.tgz#cacd802c3efba305e9062640892623e189d97dab"
+  integrity sha512-7irAZM9AA3XgpB61btlShSX8/VJUIb7WVWM/RaO5pbw2822hCXapjdVkIzOtS5kibEKMQjw9oWPM/Jad433NKQ==
   dependencies:
-    "@volar/shared" "0.28.8"
-    "@volar/source-map" "0.28.8"
+    "@volar/shared" "0.28.9"
+    "@volar/source-map" "0.28.9"
 
-"@volar/html2pug@0.28.8":
-  version "0.28.8"
-  resolved "https://registry.yarnpkg.com/@volar/html2pug/-/html2pug-0.28.8.tgz#37233d3d15a8b5308900778520ae6e52d53d8135"
-  integrity sha512-Yli7lNeRky100ubeCg0f47itPzOZx1rC/3yDkbeAOnL1blyNK7hvMEquth+EwWl8W1qEnpdqFJQR2CY5cntyjw==
+"@volar/html2pug@0.28.9":
+  version "0.28.9"
+  resolved "https://registry.yarnpkg.com/@volar/html2pug/-/html2pug-0.28.9.tgz#f64135dc67e1268645b46a82c199f41a7710ef1b"
+  integrity sha512-dQfv6reIqrXipekQD/k/nVd61CvlqJd+Y/2BNJ+atYq3d0Kx99VCjK4J7NI4bbHpccu2yXPdq+lpsvJTUUAigg==
   dependencies:
     domelementtype "^2.2.0"
     domhandler "^4.2.2"
     htmlparser2 "^7.1.2"
     pug "^3.0.2"
 
-"@volar/server@0.28.8":
-  version "0.28.8"
-  resolved "https://registry.yarnpkg.com/@volar/server/-/server-0.28.8.tgz#a7b6be802d3180faee8804d390abcbe219e68c0a"
-  integrity sha512-3+sDIqCecZlgy4n/IbINRO5c4S4XVLtuTur3GhZAHhft8NOQpBm9VMn2CtkTcqvNumMWC4ULDSwzvicoqeCcDg==
+"@volar/server@0.28.9":
+  version "0.28.9"
+  resolved "https://registry.yarnpkg.com/@volar/server/-/server-0.28.9.tgz#85f1717e04ac1c3c14c093c3206b1c6834b3350f"
+  integrity sha512-Zpz+Ud9OwUUSpwGcajWz3RBCxuCY3b5gzOR0CTqYS+o77yqPy4cn6OjwtAT4wYyKYwa6j+EgBZ0M7XFO/qCurQ==
   dependencies:
     "@starptech/prettyhtml" "^0.10.0"
-    "@volar/shared" "0.28.8"
+    "@volar/shared" "0.28.9"
     prettier "^1.16.4"
     pug-beautify "^0.1.1"
     upath "^2.0.1"
     vscode-languageserver "^8.0.0-next.2"
     vscode-languageserver-textdocument "^1.0.1"
-    vscode-vue-languageservice "0.28.8"
+    vscode-vue-languageservice "0.28.9"
 
-"@volar/shared@0.28.8":
-  version "0.28.8"
-  resolved "https://registry.yarnpkg.com/@volar/shared/-/shared-0.28.8.tgz#f0efebe4d555ac94127dd6e1366e377cd1ecaf35"
-  integrity sha512-jYm3HUbRjd5QPbBNvfD+W2fZxGjzY7QspRNAlbv0onL5zcFTz2kAQb/CYxp7WLxwKiLqjQ9A4G5BbBZvhzeMQw==
+"@volar/shared@0.28.9":
+  version "0.28.9"
+  resolved "https://registry.yarnpkg.com/@volar/shared/-/shared-0.28.9.tgz#31e952b495f378d6ab922fefff844b9013e8fb55"
+  integrity sha512-w3B7NJXebzlDhBaOumQe4hgw1nunGbaczbqzb5pkiL+V8BwmycL2T8hL+XAUQRqrrRSGhDixRwqPo36rPNvgZw==
   dependencies:
     upath "^2.0.1"
     vscode-jsonrpc "^8.0.0-next.2"
     vscode-uri "^3.0.2"
 
-"@volar/source-map@0.28.8":
-  version "0.28.8"
-  resolved "https://registry.yarnpkg.com/@volar/source-map/-/source-map-0.28.8.tgz#2cd2b853d959b91eaa35a62cbc0926e2e94ee102"
-  integrity sha512-+j6Mted0Dz2zD67dWqGg0pDomFWRrU/xYn36RjQd+UOgBEYV6i7aWqTNosc3W8FXbzbZoKosZfvEPVNpxbmxNg==
+"@volar/source-map@0.28.9":
+  version "0.28.9"
+  resolved "https://registry.yarnpkg.com/@volar/source-map/-/source-map-0.28.9.tgz#60cf148c3d475d20681a43974064f8ea052926f5"
+  integrity sha512-ZdeL9buh9ILLToe2SJWpV6LwFKo9s7I/TxnTV328tFcXU1rF81fRlgOwn/AvRfRUGUjaobB+xMdJM0/DoS1iEw==
   dependencies:
-    "@volar/shared" "0.28.8"
+    "@volar/shared" "0.28.9"
 
-"@volar/transforms@0.28.8":
-  version "0.28.8"
-  resolved "https://registry.yarnpkg.com/@volar/transforms/-/transforms-0.28.8.tgz#1635d7e3f22bea546ab92125f751555a23fe7abe"
-  integrity sha512-1oUw0luHZlBPgq3ZmkZMhIyXAvX3G5Rzp5Zx5jnMRK40yn/rUB2S+VSw1XNbb9HvG+WAOc8uLEJfaeDYNkfxqg==
+"@volar/transforms@0.28.9":
+  version "0.28.9"
+  resolved "https://registry.yarnpkg.com/@volar/transforms/-/transforms-0.28.9.tgz#b1621fa3a0acf8c85e3ca76286e2fce2aba513ac"
+  integrity sha512-vtMwgOtfgXsQiaEZs+6TO+zBleHUJDBCd34qb8dla9S3NyKK2EXmIMATuTLMWvWO7VWx7JyVIBS4zpEYq91WkQ==
   dependencies:
-    "@volar/shared" "0.28.8"
+    "@volar/shared" "0.28.9"
     vscode-languageserver "^8.0.0-next.2"
 
 "@vscode/emmet-helper@^2.8.0":
@@ -3087,25 +3087,25 @@ vscode-nls@^5.0.0:
   resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-5.0.0.tgz#99f0da0bd9ea7cda44e565a74c54b1f2bc257840"
   integrity sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA==
 
-vscode-pug-languageservice@0.28.8:
-  version "0.28.8"
-  resolved "https://registry.yarnpkg.com/vscode-pug-languageservice/-/vscode-pug-languageservice-0.28.8.tgz#49bcf0dddfdfc7adecf3e9ebbd45614206bcabe9"
-  integrity sha512-qMs5OPyKINc1SSR6lkLEp7PCvySeuA7fkU6yqmMLmhR5reEhks5T6QqpYrOfbsMco3wkKnqp7p4CA/Xo282Rhw==
+vscode-pug-languageservice@0.28.9:
+  version "0.28.9"
+  resolved "https://registry.yarnpkg.com/vscode-pug-languageservice/-/vscode-pug-languageservice-0.28.9.tgz#827776a74dee5cf0c333bb6036209e273575fda3"
+  integrity sha512-cRKhqGXjpVLgDyAUQD8/c/2h2l5vEGhn0p+pS4WE02QW60oQagkuXEjS5lfGO7Zos3VtbWeP5UxdlnxcECcSvQ==
   dependencies:
-    "@volar/code-gen" "0.28.8"
-    "@volar/shared" "0.28.8"
-    "@volar/source-map" "0.28.8"
-    "@volar/transforms" "0.28.8"
+    "@volar/code-gen" "0.28.9"
+    "@volar/shared" "0.28.9"
+    "@volar/source-map" "0.28.9"
+    "@volar/transforms" "0.28.9"
     pug-lexer "^5.0.1"
     pug-parser "^6.0.0"
     vscode-languageserver "^8.0.0-next.2"
 
-vscode-typescript-languageservice@0.28.8:
-  version "0.28.8"
-  resolved "https://registry.yarnpkg.com/vscode-typescript-languageservice/-/vscode-typescript-languageservice-0.28.8.tgz#97054fd34d716a64bee78fd1fbb3680f104d267c"
-  integrity sha512-qtvAkVQzMrJS/aaSdgVIaiUpy4e2o4wD2dml+L6Efsn0pzkM9EqAbRWNQP/gc1rcNRcvu1kFVCFdLag/eAKFag==
+vscode-typescript-languageservice@0.28.9:
+  version "0.28.9"
+  resolved "https://registry.yarnpkg.com/vscode-typescript-languageservice/-/vscode-typescript-languageservice-0.28.9.tgz#ae43a05e5318728c47783bd60682d970967dc18b"
+  integrity sha512-QxZKY5Q9mnN3VVRgyCaZwxaVmQsoXr7VfYya+9CLkr7YEgbyRSUjnjPQ/Abc3QG8YSCFHUZQkzD3nejXq3unkg==
   dependencies:
-    "@volar/shared" "0.28.8"
+    "@volar/shared" "0.28.9"
     semver "^7.3.5"
     upath "^2.0.1"
     vscode-languageserver "^8.0.0-next.2"
@@ -3121,16 +3121,16 @@ vscode-uri@^3.0.2:
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.2.tgz#ecfd1d066cb8ef4c3a208decdbab9a8c23d055d0"
   integrity sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA==
 
-vscode-vue-languageservice@0.28.8:
-  version "0.28.8"
-  resolved "https://registry.yarnpkg.com/vscode-vue-languageservice/-/vscode-vue-languageservice-0.28.8.tgz#ba1068b10c7d471533f95db2d1bb8b2e37952066"
-  integrity sha512-IPKLwOyzLXWsNqd3LOBZ/nuB/Jkoyp+UVw5fwa5stZxBmc7zLaZJEnXWmsDMBYZQsc+6D4TJK2mO8Tvh52RiFQ==
+vscode-vue-languageservice@0.28.9:
+  version "0.28.9"
+  resolved "https://registry.yarnpkg.com/vscode-vue-languageservice/-/vscode-vue-languageservice-0.28.9.tgz#f4447a7d397d16439ca7ba359404ade7f260330c"
+  integrity sha512-70qsGsvluktz507uFZ6UTbh5RTjY9xsA/EUHz7MkzjelBZmIz3E8K2SYKElj+d6eACg4DzynpxsWxnr2T6VimA==
   dependencies:
-    "@volar/code-gen" "0.28.8"
-    "@volar/html2pug" "0.28.8"
-    "@volar/shared" "0.28.8"
-    "@volar/source-map" "0.28.8"
-    "@volar/transforms" "0.28.8"
+    "@volar/code-gen" "0.28.9"
+    "@volar/html2pug" "0.28.9"
+    "@volar/shared" "0.28.9"
+    "@volar/source-map" "0.28.9"
+    "@volar/transforms" "0.28.9"
     "@vscode/emmet-helper" "^2.8.0"
     "@vue/compiler-dom" "^3.2.20"
     "@vue/reactivity" "^3.2.20"
@@ -3142,8 +3142,8 @@ vscode-vue-languageservice@0.28.8:
     vscode-json-languageservice "^4.1.8"
     vscode-languageserver "^8.0.0-next.2"
     vscode-languageserver-textdocument "^1.0.1"
-    vscode-pug-languageservice "0.28.8"
-    vscode-typescript-languageservice "0.28.8"
+    vscode-pug-languageservice "0.28.9"
+    vscode-typescript-languageservice "0.28.9"
 
 which@^1.2.9:
   version "1.3.1"


### PR DESCRIPTION
There was a change to "splitEditors" in upstream. Leave `coc-volar` with its existing behavior for now.