### PR TITLE
Revert "feat: add typescript, javascript and related to jsx to activationEvents"

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,18 +42,22 @@ In this case, please execute the command to restart the language server.
 - <https://github.com/johnsoncodehk/volar/tree/master/extensions/vscode-vue-language-features#using>
 - <https://github.com/johnsoncodehk/volar/tree/master/extensions/vscode-vue-language-features#note>
 
-## How to enable "Take Over Mode" in coc-volar
+## How to enable "TakeOverMode" in coc-volar
 
-### If you are using "Take Over Mode" for the first time in your project
+### If you are using "TakeOverMode" for the first time in your project
 
-1. To begin, open the `*.vue`, `*.ts`, `*.js`, `*.tsx`, `*.jsx` file.
+1. [Must] To begin, open the `*.vue` file. (Do not open the `*.ts` file first!)
 1. Then run `:CocCommand volar.initializeTakeOverMode`.
-1. When prompted by `Enable Take Over Mode? (y/n)?`, enter `y`
+1. When prompted by `Enable TakeOverMode? (y/n)?`, enter `y`
 1. The `.vim/coc-settings.json` file will be created in the "project root".
    - The `"volar.takeOverMode.enabled": true` and `"tsserver.enable": false` settings will be added.
 1. `coc.nvim` will be restarted and the settings will be reflected.
 
-### If you want to disable Take Over Mode for a project
+### If the project already has "TakeOverMode" enabled
+
+1. [Must] To begin, open the `*.vue` file. (Do not open the `*.ts` file first!)
+
+### If you want to disable TakeOverMode for a project
 
 Delete the `.vim/coc-settings.json` file in the "project root", and start Vim again.
 

--- a/package.json
+++ b/package.json
@@ -51,10 +51,6 @@
   },
   "activationEvents": [
     "onLanguage:vue",
-    "onLanguage:javascript",
-    "onLanguage:typescript",
-    "onLanguage:javascriptreact",
-    "onLanguage:typescriptreact",
     "onCommand:volar.initializeTakeOverMode"
   ],
   "contributes": {

--- a/src/client/commands.ts
+++ b/src/client/commands.ts
@@ -7,11 +7,8 @@ export function doctorCommand(context: ExtensionContext) {
     const { document } = await workspace.getCurrentState();
     const filePath = Uri.parse(document.uri).fsPath;
 
-    const supportlanguages = ['vue', 'javascript', 'typescript', 'javascriptreact', 'typescriptreact'];
-    if (!supportlanguages.includes(document.languageId)) {
-      return window.showInformationMessage(
-        'volar.doctor has failed. The current languageId does not support the volar.doctor command.'
-      );
+    if (!filePath.endsWith('.vue')) {
+      return window.showInformationMessage('Failed to doctor. Make sure the current file is a .vue file.');
     }
 
     const clientJSON = path.join(context.extensionPath, 'package.json');
@@ -100,7 +97,7 @@ export function doctorCommand(context: ExtensionContext) {
 
 export function initializeTakeOverModeCommand() {
   return async () => {
-    const enableTakeOverMode = await window.showPrompt('Enable Take Over Mode?');
+    const enableTakeOverMode = await window.showPrompt('Enable TakeOverMode?');
     const config = workspace.getConfiguration('volar');
     const tsserverConfig = workspace.getConfiguration('tsserver');
 


### PR DESCRIPTION
Reverts yaegassy/coc-volar#114

---

Confirmed that the volar server is starting up even though the project is not Vue. For example, autocompletion is duplicated.

<img width="740" alt="capture" src="https://user-images.githubusercontent.com/188642/151906971-3cc5be60-99c4-414d-8fe7-1e031466b1c1.png">

Reverts...