### PR TITLE
feat(command): add "volar.usePrettier" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Delete the `.vim/coc-settings.json` file in the "project root", and start Vim ag
   - You can check the versions and settings of various packages
     - client, server, vue, @vue/runtime-dom, vue-tsc, typescript related, coc-volar's configuration, and more...
 - `volar.initializeTakeOverMode`: Enable Take Over Mode in your project
+- `volar.usePrettier`: Disable volar formatter and enable prettier in your project
 - `volar.action.restartServer`: Restart Vue server
 - `volar.action.verifyAllScripts`: Verify All Scripts
 - `volar.action.splitEditors`: Split `<script>`, `<template>`, `<style>` Editors

--- a/package.json
+++ b/package.json
@@ -257,6 +257,11 @@
         "category": "Volar"
       },
       {
+        "command": "volar.usePrettier",
+        "title": "Disable volar formatter and enable prettier in your project",
+        "category": "Volar"
+      },
+      {
         "command": "volar.action.restartServer",
         "title": "Restart Vue server",
         "category": "Volar"

--- a/src/client/commands.ts
+++ b/src/client/commands.ts
@@ -1,4 +1,4 @@
-import { ExtensionContext, Uri, window, workspace } from 'coc.nvim';
+import { extensions, ExtensionContext, Uri, window, workspace } from 'coc.nvim';
 import path from 'path';
 import fs from 'fs';
 
@@ -110,6 +110,26 @@ export function initializeTakeOverModeCommand() {
     }
 
     workspace.nvim.command(`CocRestart`, true);
+  };
+}
+
+export function usePrettierCommand() {
+  return async () => {
+    const usePrettier = await window.showPrompt('Disable volar formatter and enable prettier in your project?');
+
+    let isCocPretteir = true;
+    if (!extensions.all.find((e) => e.id === 'coc-prettier')) {
+      isCocPretteir = false;
+      window.showWarningMessage(`coc-prettier is not installed`);
+    }
+
+    if (usePrettier && isCocPretteir) {
+      const config = workspace.getConfiguration('volar');
+      const prettierConfig = workspace.getConfiguration('prettier');
+      config.update('formatting.enable', false);
+      prettierConfig.update('disableLanguages', []);
+      workspace.nvim.command(`CocRestart`, true);
+    }
   };
 }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -11,7 +11,7 @@ import * as splitEditors from './features/splitEditors';
 import * as tsVersion from './features/tsVersion';
 import * as verifyAll from './features/verifyAll';
 
-import { doctorCommand, initializeTakeOverModeCommand } from './client/commands';
+import { doctorCommand, initializeTakeOverModeCommand, usePrettierCommand } from './client/commands';
 
 let apiClient: LanguageClient;
 let docClient: LanguageClient | undefined;
@@ -174,6 +174,8 @@ export async function doActivate(context: ExtensionContext, createLc: CreateLang
 
   /** MEMO: Custom commands for coc-volar */
   context.subscriptions.push(commands.registerCommand('volar.doctor', doctorCommand(context)));
+  /** MEMO: Custom commands for coc-volar */
+  context.subscriptions.push(commands.registerCommand('volar.usePrettier', usePrettierCommand()));
 }
 
 function getInitializationOptions(


### PR DESCRIPTION
## Description

This command disables the built-in formatter provided by volar's language server, and enables "prettier".

Used to quickly enable pretteir in a new Vue project created with `create-vue`, etc.

To use prettier, you need `coc-prettier`. As an additional note, vue files are disabled by default in coc-prettier.

## DEMO (mp4)

https://user-images.githubusercontent.com/188642/153787961-2224901f-85a2-41ba-b403-2bf482f8fe82.mp4
