### PR TITLE
feat(completion): add "volar.scaffoldSnippets.enable" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Delete the `.vim/coc-settings.json` file in the "project root", and start Vim ag
 
 - `volar.enable`: Enable coc-volar extension, default: `true`
 - `volar.useWorkspaceTsdk`: Use workspace (project) detected tsLibs in volar. if false, use coc-volar's built-in tsLibs, default: `false`
+- `volar.scaffoldSnippets.enable`: Enable/disable scaffold snippets completion. Typing `vue` or `vuedc` will output completion suggestions. This snippets completion feature will only work on the first line of the file, default: `true`
 - `volar.diagnostics.enable`: Enable/disable the Volar diagnostics, default: `true`
 - `volar.diagnostics.tsLocale`: Locale of diagnostics messages from typescript, valid option: `["cs", "de", "es", "fr", "it", "ja", "ko", "en", "pl", "pt-br", "ru", "tr", "zh-cn", "zh-tw"]`, default: `"en"`
 - `volar.maxMemory`: Maximum memory (in MB) that the server should use. On some systems this may only have effect when runtime has been set. Minimum 256.

--- a/package.json
+++ b/package.json
@@ -82,6 +82,11 @@
           "default": false,
           "description": "Use workspace (project) detected tsLibs in volar. if false, use coc-volar's built-in tsLibs."
         },
+        "volar.scaffoldSnippets.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable/disable scaffold snippets completion. Typing `vue` or `vuedc` will output completion suggestions. This snippets completion feature will only work on the first line of the file."
+        },
         "volar.diagnostics.enable": {
           "type": "boolean",
           "default": true,

--- a/snippets/vue.code-snippets
+++ b/snippets/vue.code-snippets
@@ -1,0 +1,40 @@
+{
+  "vue": {
+    "prefix": "vue",
+    "body": [
+      "<script ${1:setup }${2:lang=\"${3|ts,js,tsx,jsx|}\"}>",
+      "$0",
+      "</script>",
+      "  ",
+      "<template>",
+      "  ",
+      "</template>",
+      "  ",
+      "<style scoped>",
+      "  ",
+      "</style>"
+    ],
+    "description": "default"
+  },
+  "vue-define-component": {
+    "prefix": "vuedc",
+    "body": [
+      "<script ${1:lang=\"${3|ts,js,tsx,jsx|}\"}>",
+      "import { defineComponent } from 'vue';",
+      "",
+      "export default defineComponent({",
+      "  $0",
+      "});",
+      "</script>",
+      "  ",
+      "<template>",
+      "  ",
+      "</template>",
+      "  ",
+      "<style scoped>",
+      "  ",
+      "</style>"
+    ],
+    "description": "defineComponent"
+  }
+}

--- a/src/client/completions.ts
+++ b/src/client/completions.ts
@@ -1,0 +1,97 @@
+import {
+  CancellationToken,
+  CompletionContext,
+  CompletionItem,
+  CompletionItemKind,
+  CompletionItemProvider,
+  CompletionList,
+  ExtensionContext,
+  InsertTextFormat,
+  Position,
+  TextDocument,
+  workspace,
+} from 'coc.nvim';
+
+import path from 'path';
+import fs from 'fs';
+
+type SnippetsJsonType = {
+  [key: string]: {
+    description: string;
+    prefix: string;
+    body: string | string[];
+  };
+};
+
+export class scaffoldSnippetsCompletionProvider implements CompletionItemProvider {
+  private _context: ExtensionContext;
+  private snippetsFilePaths: string[];
+
+  constructor(context: ExtensionContext) {
+    this._context = context;
+    this.snippetsFilePaths = [path.join(this._context.extensionPath, 'snippets', 'vue.code-snippets')];
+  }
+
+  async getSnippetsCompletionItems(snippetsFilePath: string) {
+    const snippetsCompletionList: CompletionItem[] = [];
+    if (fs.existsSync(snippetsFilePath)) {
+      const snippetsJsonText = fs.readFileSync(snippetsFilePath, 'utf8');
+      const snippetsJson: SnippetsJsonType = JSON.parse(snippetsJsonText);
+      if (snippetsJson) {
+        Object.keys(snippetsJson).map((key) => {
+          let snippetsText: string;
+          const body = snippetsJson[key].body;
+          if (body instanceof Array) {
+            snippetsText = body.join('\n');
+          } else {
+            snippetsText = body;
+          }
+
+          // In this extention, "insertText" is handled by "resolveCompletionItem".
+          // In "provideCompletionItems", if "insertText" contains only snippets data,
+          // it will be empty when the candidate is selected.
+          snippetsCompletionList.push({
+            label: snippetsJson[key].prefix,
+            kind: CompletionItemKind.Snippet,
+            filterText: snippetsJson[key].prefix,
+            detail: snippetsJson[key].description,
+            documentation: { kind: 'markdown', value: '```vue\n' + snippetsText + '\n```' },
+            insertTextFormat: InsertTextFormat.Snippet,
+            // The "snippetsText" that will eventually be added to the insertText
+            // will be stored in the "data" key
+            data: snippetsText,
+          });
+        });
+      }
+    }
+
+    return snippetsCompletionList;
+  }
+
+  async provideCompletionItems(
+    document: TextDocument,
+    position: Position,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    token: CancellationToken,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    context: CompletionContext
+  ): Promise<CompletionItem[] | CompletionList> {
+    if (position.line !== 0) return [];
+    const doc = workspace.getDocument(document.uri);
+    if (!doc) return [];
+    const completionItemList: CompletionItem[] = [];
+    this.snippetsFilePaths.forEach((v) => {
+      this.getSnippetsCompletionItems(v).then((vv) => completionItemList.push(...vv));
+    });
+
+    return completionItemList;
+  }
+
+  async resolveCompletionItem(item: CompletionItem): Promise<CompletionItem> {
+    if (item.kind === CompletionItemKind.Snippet) {
+      item.insertText = item.data;
+    }
+
+    return item;
+  }
+}


### PR DESCRIPTION
## Description

Enable vetur's like scaffold snippets. Try typing `vue` or ` vuedc`.

**Add configuration option**:

- `volar.scaffoldSnippets.enable`: Enable/disable scaffold snippets completion. Typing `vue` or `vuedc` will output completion suggestions. This snippets completion feature will only work on the first line of the file, default: `true`

## DEMO (mp4)

https://user-images.githubusercontent.com/188642/154611535-3d4a4102-2788-4c5f-9dca-256e2046aa64.mp4

## Misc

If you need other snippets, try using [coc-snippets](https://github.com/neoclide/coc-snippets) or similar vim plugin.