### PR TITLE
refactor: remove "volar.usePrettier" command and docs adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,32 @@ In this case, please execute the command to restart the language server.
 
 Delete the `.vim/coc-settings.json` file in the "project root", and start Vim again.
 
+## Formatter
+
+If `coc-prettier` (v9.2.0 later) is installed, `prettier` will be run as the formatter.
+
+If you want to use the volar's built-in formatter, set `prettier.formatterPriority` to `-1` in `.vim/coc-settings.json`.
+
+```jsonc
+{
+  "prettier.formatterPriority": -1,
+}
+```
+
+Or set `prettier.disableLanguages` to `vue` in `.vim/coc-settings.json`.
+
+```jsonc
+{
+  "prettier.disableLanguages": [
+    "vue"
+  ]
+}
+```
+
+It can also be controlled by other `coc-prettier` settings and `.prettierignore` files.
+
+Check the README of `coc-prettier` for details. <https://github.com/neoclide/coc-prettier/blob/master/Readme.md>
+
 ## Configuration options
 
 - `volar.enable`: Enable coc-volar extension, default: `true`
@@ -87,7 +113,6 @@ Delete the `.vim/coc-settings.json` file in the "project root", and start Vim ag
   - You can check the versions and settings of various packages
     - client, server, vue, @vue/runtime-dom, vue-tsc, typescript related, coc-volar's configuration, and more...
 - `volar.initializeTakeOverMode`: Enable Take Over Mode in your project
-- `volar.usePrettier`: Disable volar formatter and enable prettier in your project
 - `volar.action.restartServer`: Restart Vue server
 - `volar.action.verifyAllScripts`: Verify All Scripts
 - `volar.action.splitEditors`: Split `<script>`, `<template>`, `<style>` Editors

--- a/package.json
+++ b/package.json
@@ -262,11 +262,6 @@
         "category": "Volar"
       },
       {
-        "command": "volar.usePrettier",
-        "title": "Disable volar formatter and enable prettier in your project",
-        "category": "Volar"
-      },
-      {
         "command": "volar.action.restartServer",
         "title": "Restart Vue server",
         "category": "Volar"

--- a/src/client/commands.ts
+++ b/src/client/commands.ts
@@ -113,26 +113,6 @@ export function initializeTakeOverModeCommand() {
   };
 }
 
-export function usePrettierCommand() {
-  return async () => {
-    const usePrettier = await window.showPrompt('Disable volar formatter and enable prettier in your project?');
-
-    let isCocPretteir = true;
-    if (!extensions.all.find((e) => e.id === 'coc-prettier')) {
-      isCocPretteir = false;
-      window.showWarningMessage(`coc-prettier is not installed`);
-    }
-
-    if (usePrettier && isCocPretteir) {
-      const config = workspace.getConfiguration('volar');
-      const prettierConfig = workspace.getConfiguration('prettier');
-      config.update('formatting.enable', false);
-      prettierConfig.update('disableLanguages', []);
-      workspace.nvim.command(`CocRestart`, true);
-    }
-  };
-}
-
 function getPackageVersionFromJson(packageJsonPath: string): string | undefined {
   let version: string | undefined;
   try {

--- a/src/common.ts
+++ b/src/common.ts
@@ -11,7 +11,7 @@ import * as splitEditors from './features/splitEditors';
 import * as tsVersion from './features/tsVersion';
 import * as verifyAll from './features/verifyAll';
 
-import { doctorCommand, initializeTakeOverModeCommand, usePrettierCommand } from './client/commands';
+import { doctorCommand, initializeTakeOverModeCommand } from './client/commands';
 import { scaffoldSnippetsCompletionProvider } from './client/completions';
 
 let apiClient: LanguageClient;
@@ -175,8 +175,6 @@ export async function doActivate(context: ExtensionContext, createLc: CreateLang
 
   /** MEMO: Custom commands for coc-volar */
   context.subscriptions.push(commands.registerCommand('volar.doctor', doctorCommand(context)));
-  /** MEMO: Custom commands for coc-volar */
-  context.subscriptions.push(commands.registerCommand('volar.usePrettier', usePrettierCommand()));
   /** MEMO: Custom snippets completion for coc-volar */
   if (getConfigScaffoldSnippetsCompletion()) {
     context.subscriptions.push(


### PR DESCRIPTION
## Description

The default value of `prettier.disableLanguages` has been changed in `coc-prettier` since "v9.2.0". Previously, `vue` was set to disable by default.

- **REF**:
  - <https://github.com/neoclide/coc-prettier/issues/145>
  - <https://github.com/neoclide/coc-prettier/blob/master/package.json#L42>

Because of this, if coc-prettier is installed, the built-in formatter of the Language Server (e.g. volar) will not be used, and prettier will be used preferentially.

For this reason, the `volar.usePrettier` command is unnecessary and has been removed.

## If you want to use volar's built-in formatter

Added explanation to README.