### PR TITLE
refactor: sync volar v0.32.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -279,8 +279,8 @@
     ]
   },
   "dependencies": {
-    "@volar/server": "0.31.4",
-    "@volar/shared": "0.31.4",
+    "@volar/server": "0.32.0",
+    "@volar/shared": "0.32.0",
     "@vue/reactivity": "3.2.27",
     "typescript": "4.5.4",
     "vscode-html-languageservice": "^4.1.0",

--- a/src/client/commands.ts
+++ b/src/client/commands.ts
@@ -1,4 +1,4 @@
-import { extensions, ExtensionContext, Uri, window, workspace } from 'coc.nvim';
+import { ExtensionContext, Uri, window, workspace } from 'coc.nvim';
 import path from 'path';
 import fs from 'fs';
 

--- a/src/features/tsVersion.ts
+++ b/src/features/tsVersion.ts
@@ -1,28 +1,26 @@
 import { ExtensionContext, Uri, workspace } from 'coc.nvim';
-import * as shared from '@volar/shared';
 import path from 'path';
 import fs from 'fs';
 
 const defaultTsdk = 'node_modules/typescript/lib';
 
 export function getCurrentTsPaths(context: ExtensionContext) {
-  if (isUseWorkspaceTsdk()) {
+  if (getConfigUseWorkspaceTsdk()) {
     const workspaceTsPaths = getWorkspaceTsPaths(true);
     if (workspaceTsPaths) {
       return { ...workspaceTsPaths, isWorkspacePath: true };
     }
   }
 
-  const tsLocale = getTsLocale();
+  const tsLocalizedLang = getConfigDiagnosticsTsLocale();
   const tsLocaleJsonPath = path.join(
     context.extensionPath,
     'node_modules',
     'typescript',
     'lib',
-    tsLocale,
+    tsLocalizedLang,
     'diagnosticMessages.generated.json'
   );
-
   const localizedPath = fs.existsSync(tsLocaleJsonPath) ? tsLocaleJsonPath : undefined;
 
   const builtinTsPaths = {
@@ -34,18 +32,18 @@ export function getCurrentTsPaths(context: ExtensionContext) {
 }
 
 function getWorkspaceTsPaths(useDefault = false) {
-  let tsdk = getTsdk();
+  let tsdk = getConfigCocTsserverTsdk();
   if (!tsdk && useDefault) {
     tsdk = defaultTsdk;
   }
   if (tsdk) {
-    const tsPath = shared.getWorkspaceTypescriptPath(
+    const tsPath = getWorkspaceTypescriptPath(
       tsdk,
       workspace.workspaceFolders.map((folder) => Uri.parse(folder.uri).fsPath)
     );
     if (tsPath) {
-      const tsLocale = getTsLocale();
-      const tsLocaleJsonPath = path.join(path.dirname(tsPath), tsLocale, 'diagnosticMessages.generated.json');
+      const tsLocalizedLang = getConfigDiagnosticsTsLocale();
+      const tsLocaleJsonPath = path.join(path.dirname(tsPath), tsLocalizedLang, 'diagnosticMessages.generated.json');
       const localizedPath = fs.existsSync(tsLocaleJsonPath) ? tsLocaleJsonPath : undefined;
 
       return {
@@ -56,19 +54,49 @@ function getWorkspaceTsPaths(useDefault = false) {
   }
 }
 
-function getTsdk() {
-  // MEMO: tsserver.tsdk for coc-tsserver
-  const tsConfigs = workspace.getConfiguration('tsserver');
-  const tsdk = tsConfigs.get<string>('tsdk');
-  return tsdk;
+function getWorkspaceTypescriptPath(tsdk: string, workspaceFolderFsPaths: string[]) {
+  if (path.isAbsolute(tsdk)) {
+    const tsPath = findTypescriptModulePathInLib(tsdk);
+    if (tsPath) {
+      return tsPath;
+    }
+  } else {
+    for (const folder of workspaceFolderFsPaths) {
+      const tsPath = findTypescriptModulePathInLib(path.join(folder, tsdk));
+      if (tsPath) {
+        return tsPath;
+      }
+    }
+  }
 }
 
-function isUseWorkspaceTsdk() {
-  // MEMO: volar.useWorkspaceTsdk for coc-volar
+function findTypescriptModulePathInLib(lib: string) {
+  const tsserverlibrary = path.join(lib, 'tsserverlibrary.js');
+  const typescript = path.join(lib, 'typescript.js');
+  const tsserver = path.join(lib, 'tsserver.js');
+
+  if (fs.existsSync(tsserverlibrary)) {
+    return tsserverlibrary;
+  }
+  if (fs.existsSync(typescript)) {
+    return typescript;
+  }
+  if (fs.existsSync(tsserver)) {
+    return tsserver;
+  }
+}
+
+// Memo: volar.useWorkspaceTsdk for coc-volar
+function getConfigUseWorkspaceTsdk() {
   return workspace.getConfiguration('volar').get<boolean>('useWorkspaceTsdk', false);
 }
 
-function getTsLocale() {
-  // MEMO: volar.diagnostics.tsLocale for coc-volar
+// Memo: volar.diagnostics.tsLocale for coc-volar
+function getConfigDiagnosticsTsLocale() {
   return workspace.getConfiguration('volar').get<string>('diagnostics.tsLocale', 'en');
+}
+
+// Memo: tsserver.tsdk for coc-tsserver
+function getConfigCocTsserverTsdk() {
+  return workspace.getConfiguration('tsserver').get<string>('tsdk');
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     if (devVolarServerPath && fs.existsSync(devVolarServerPath)) {
       serverModule = workspace.expand(devVolarServerPath);
     } else {
-      serverModule = context.asAbsolutePath(path.join('node_modules', '@volar', 'server', 'out', 'index.js'));
+      serverModule = context.asAbsolutePath(path.join('node_modules', '@volar', 'server', 'out', 'node'));
     }
 
     const debugOptions = { execArgv: ['--nolazy', '--inspect=' + port] };

--- a/yarn.lock
+++ b/yarn.lock
@@ -385,75 +385,79 @@
     "@typescript-eslint/types" "5.10.2"
     eslint-visitor-keys "^3.0.0"
 
-"@volar/code-gen@0.31.4":
-  version "0.31.4"
-  resolved "https://registry.yarnpkg.com/@volar/code-gen/-/code-gen-0.31.4.tgz#df4157b0eb59193a0b5c8352aeeb29a5d651556c"
-  integrity sha512-ngivMEbBNd19v+EHdLyCJoIGRaoD9J4P20ZgdCEGf2voztja59u3Tilpf9r9ENy/731nG7XncToYm4+c1t/LhA==
+"@volar/code-gen@0.32.0":
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/@volar/code-gen/-/code-gen-0.32.0.tgz#05bcb66e21b72a9ed632524d320323b1d9d0e579"
+  integrity sha512-vxXKzZs9DMf/iBEAFJRwPVCk6CQFYZjul9iQ9GZCAjmy2lotSvv5jBQm5unzIAQQpKv4HH3jfA0YD0aT58S4eQ==
   dependencies:
-    "@volar/shared" "0.31.4"
-    "@volar/source-map" "0.31.4"
+    "@volar/shared" "0.32.0"
+    "@volar/source-map" "0.32.0"
 
-"@volar/html2pug@0.31.4":
-  version "0.31.4"
-  resolved "https://registry.yarnpkg.com/@volar/html2pug/-/html2pug-0.31.4.tgz#711c71bd3cbe91cae6806e06a8e41d806b39cf2a"
-  integrity sha512-+whoP4C34kbCIRyoojZE6luqs7Ep/0YDBD9yEWu82G1ECLIFoujtkZXHbAHiQH8MIs/GwjUmozd85pUGAVQf1w==
+"@volar/html2pug@0.32.0":
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/@volar/html2pug/-/html2pug-0.32.0.tgz#aaa7026d8162a0a54df0eb19ecfc20acf56ae813"
+  integrity sha512-VPu7O7x74KbUSOofpOH4dxH4jUpKF+9VmsY9ehXftOcuknlBV8v7o0RlIYDrirjq5kUINGJwalKJF33tjR5kTA==
   dependencies:
     domelementtype "^2.2.0"
     domhandler "^4.3.0"
     htmlparser2 "^7.2.0"
     pug "^3.0.2"
 
-"@volar/server@0.31.4":
-  version "0.31.4"
-  resolved "https://registry.yarnpkg.com/@volar/server/-/server-0.31.4.tgz#fb92188b44836a2f540e5aa58c5d7e0494818d67"
-  integrity sha512-CtFnbwuquerm+HViTD5SdSJ+xw9BeFv/wmp/CX6Slw1YQ/VCkP+Tiz1FN21bUGzyJ+IJk3NCw5INwACtok8jqA==
+"@volar/server@0.32.0":
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/@volar/server/-/server-0.32.0.tgz#195dae6f92150dcd8b7aa49606f6a82fcf203150"
+  integrity sha512-0d2qaO67yM6eMecuoBpy/Tle71Ta1sN+D8+o7bKESDEzXZVaMazqyh4blREAj6dTaJLaMnAr4+CHwzyBYWO8zQ==
   dependencies:
     "@starptech/prettyhtml" "^0.10.0"
-    "@volar/shared" "0.31.4"
+    "@volar/html2pug" "0.32.0"
+    "@volar/shared" "0.32.0"
+    "@volar/vue-code-gen" "0.32.0"
+    "@vue/shared" "^3.2.27"
     prettier "^1.16.4"
     pug-beautify "^0.1.1"
     request-light "^0.5.7"
     sass-formatter "^0.7.2"
     upath "^2.0.1"
     vscode-languageserver "^8.0.0-next.6"
+    vscode-languageserver-protocol "^3.17.0-next.12"
     vscode-languageserver-textdocument "^1.0.3"
     vscode-uri "^3.0.3"
-    vscode-vue-languageservice "0.31.4"
+    vscode-vue-languageservice "0.32.0"
 
-"@volar/shared@0.31.4":
-  version "0.31.4"
-  resolved "https://registry.yarnpkg.com/@volar/shared/-/shared-0.31.4.tgz#aa5cdcd0a58fd12b7b767e014042c88ad78d19ed"
-  integrity sha512-mKSH4GKFde2t3GVEGibBu84jbCk7O1sccELxTgCGHX7ue4nJqgHup8lXhwyfUOfdJ7eyx9luyDsVuJ4BY3gfeg==
+"@volar/shared@0.32.0":
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/@volar/shared/-/shared-0.32.0.tgz#98b96ac23be2388c4817dcefd92285d99eebdb12"
+  integrity sha512-RzpoyRAJlEjqAi0rsrqHn5aRJ+xi58JrXa+NCNuJOuGLhUKbPyR9n8JUI+mF4h01opYl3C/s8qYmWQQBOpBUUg==
   dependencies:
     upath "^2.0.1"
     vscode-html-languageservice "^4.2.1"
     vscode-jsonrpc "^8.0.0-next.5"
     vscode-uri "^3.0.3"
 
-"@volar/source-map@0.31.4":
-  version "0.31.4"
-  resolved "https://registry.yarnpkg.com/@volar/source-map/-/source-map-0.31.4.tgz#c0ae071b007e560507e28db5ca382a6645f64c85"
-  integrity sha512-lX/XKKc3ESNt6QArq1T54LSxXvu7ARDctQfkt6qUSNLVR/ccUXwzM+4qiOj39WBbmoDzET33riVYnMXMeGJMvg==
+"@volar/source-map@0.32.0":
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/@volar/source-map/-/source-map-0.32.0.tgz#b93438d39aaca8b518d30c9a54e0362ea854803c"
+  integrity sha512-DRDRvgPZtF/2Me+NBpGQ/bdK0uro7qOneoU1Xhrjmx7dwFB2QNxwEF2BXndmo7BNIc9Rc7g1AYvMRw3y80IhnQ==
   dependencies:
-    "@volar/shared" "0.31.4"
+    "@volar/shared" "0.32.0"
     vscode-languageserver-textdocument "^1.0.3"
 
-"@volar/transforms@0.31.4":
-  version "0.31.4"
-  resolved "https://registry.yarnpkg.com/@volar/transforms/-/transforms-0.31.4.tgz#085c40adce8730929f27b41c60dfca4d286a8b0c"
-  integrity sha512-081QI2zBvdja4XN3eAtIWmBqDkAyDuuK3xP5mD04T9vMrVfy+WKrzB7n3/Zru7z4DiM70Qo5PoTapQ3Xnz9NzQ==
+"@volar/transforms@0.32.0":
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/@volar/transforms/-/transforms-0.32.0.tgz#a161a3f921f87a400d87cbb9a1e25d81648d1e4d"
+  integrity sha512-F1ppg60SmPEaJmUfTTP0ZtXFe2u0HURklhFGaKnZ608yIBHq4EGW/kzH8xGc8TjrdGjrWpKkr9D+SHLpq5tirQ==
   dependencies:
-    "@volar/shared" "0.31.4"
+    "@volar/shared" "0.32.0"
     vscode-languageserver-types "^3.17.0-next.6"
 
-"@volar/vue-code-gen@0.31.4":
-  version "0.31.4"
-  resolved "https://registry.yarnpkg.com/@volar/vue-code-gen/-/vue-code-gen-0.31.4.tgz#69124ded85513035beeb752a79f860212d78875c"
-  integrity sha512-1ypZfzQfH+lV8JcOOKfYMTAmD6OUeBQSDwu7YRHQkuvoSQzPiXXrjupi0DvHrcWR0hQfh4yRnme6I+ChutW69w==
+"@volar/vue-code-gen@0.32.0":
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/@volar/vue-code-gen/-/vue-code-gen-0.32.0.tgz#aba86b056d70e8a2076c75b53c081a9b3fdb178c"
+  integrity sha512-NxSYTvCEIDRj6kym/HSa4XIqA473emyVaWApFmg7mpd7ZoadyfhHPd7UuYB90uwMBj0oNQ53+BnvDhCgUMj+Tw==
   dependencies:
-    "@volar/code-gen" "0.31.4"
-    "@volar/shared" "0.31.4"
-    "@volar/source-map" "0.31.4"
+    "@volar/code-gen" "0.32.0"
+    "@volar/shared" "0.32.0"
+    "@volar/source-map" "0.32.0"
     "@vue/compiler-core" "^3.2.27"
     "@vue/compiler-dom" "^3.2.27"
     "@vue/shared" "^3.2.27"
@@ -3460,14 +3464,14 @@ vscode-html-languageservice@^4.1.0:
     vscode-uri "^3.0.2"
 
 vscode-html-languageservice@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/vscode-html-languageservice/-/vscode-html-languageservice-4.2.1.tgz#b95077cffd19bf187e53c7bf79e3e0dd7edbc7cf"
-  integrity sha512-PgaToZVXJ44nFWEBuSINdDgVV6EnpC3MnXBsysR3O5TKcAfywbYeRGRy+Y4dVR7YeUgDvtb+JkJoSkaYC0mxXQ==
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/vscode-html-languageservice/-/vscode-html-languageservice-4.2.2.tgz#e580b8f22b1b8c1dc0d6aaeda5a861f8b4120e4e"
+  integrity sha512-4ICwlpplGbiNQq6D/LZr4qLbPZuMmnSQeX/57UAYP7jD1LOvKeru4lVI+f6d6Eyd7uS46nLJ5DUY4AAlq35C0g==
   dependencies:
-    vscode-languageserver-textdocument "^1.0.1"
+    vscode-languageserver-textdocument "^1.0.3"
     vscode-languageserver-types "^3.16.0"
     vscode-nls "^5.0.0"
-    vscode-uri "^3.0.2"
+    vscode-uri "^3.0.3"
 
 vscode-json-languageservice@^4.1.10:
   version "4.1.10"
@@ -3485,10 +3489,15 @@ vscode-jsonrpc@8.0.0-next.2:
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.0-next.2.tgz#285fc294be586e4768acd67e5a42efc738a5cac0"
   integrity sha512-gxUyTBAjmwGkiHW/UaRScre2s4i98P8M7gnc3VB4DrVQUm3vQ0idi2cN9nbkfcjATx+uEt8C22j+MLN/8UzsJA==
 
-vscode-jsonrpc@8.0.0-next.5, vscode-jsonrpc@^8.0.0-next.5:
+vscode-jsonrpc@8.0.0-next.5:
   version "8.0.0-next.5"
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.0-next.5.tgz#44ac984fd8a849b8a351611d5867411226885988"
   integrity sha512-owRllqcFTnz5rXxcbmHPFGmpFmLqj9Z1V3Dzrv+s8ejOHLIT62Pyb5Uqzyl2/in2VP22DmzErPgZwrxjLCIKiQ==
+
+vscode-jsonrpc@^8.0.0-next.5:
+  version "8.0.0-next.6"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.0-next.6.tgz#981f7c065ecc7e7e8595f9da6d073ac592b34114"
+  integrity sha512-6Ld3RYjygn5Ih7CkAtcAwiDQC+rakj2O+PnASfNyYv3sLmm44eJpEKzuPUN30Iy2UB09AZg8T6LBKWTJTEJDVw==
 
 vscode-languageclient@^8.0.0-next.2:
   version "8.0.0-next.2"
@@ -3552,26 +3561,26 @@ vscode-nls@^5.0.0:
   resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-5.0.0.tgz#99f0da0bd9ea7cda44e565a74c54b1f2bc257840"
   integrity sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA==
 
-vscode-pug-languageservice@0.31.4:
-  version "0.31.4"
-  resolved "https://registry.yarnpkg.com/vscode-pug-languageservice/-/vscode-pug-languageservice-0.31.4.tgz#4679a961607e5f9692bd14156842c9f13582ef61"
-  integrity sha512-StQWV+v1v+an/pGKNPg4YkODFyKeYpUEzaSAoXIUsIoh7O4Nuv6zjd1M/fPxaMSD6Kk+OH/JGE36hbXsKXOz5A==
+vscode-pug-languageservice@0.32.0:
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/vscode-pug-languageservice/-/vscode-pug-languageservice-0.32.0.tgz#1aea3cad4736014001260b946c67d95d44693d7e"
+  integrity sha512-6ACeoDERB0PZNEj9ZwHVRQl084PKw48CYLq2nWSzgpZNwg+bxH/D5CLE7wyRWnF1s78tHCa8gpIKcWlTPL8jgA==
   dependencies:
-    "@volar/code-gen" "0.31.4"
-    "@volar/shared" "0.31.4"
-    "@volar/source-map" "0.31.4"
-    "@volar/transforms" "0.31.4"
+    "@volar/code-gen" "0.32.0"
+    "@volar/shared" "0.32.0"
+    "@volar/source-map" "0.32.0"
+    "@volar/transforms" "0.32.0"
     pug-lexer "^5.0.1"
     pug-parser "^6.0.0"
     vscode-languageserver-textdocument "^1.0.3"
     vscode-languageserver-types "^3.17.0-next.6"
 
-vscode-typescript-languageservice@0.31.4:
-  version "0.31.4"
-  resolved "https://registry.yarnpkg.com/vscode-typescript-languageservice/-/vscode-typescript-languageservice-0.31.4.tgz#b71819c52dc8dfdb3153a398c24661f62886a4ae"
-  integrity sha512-nsnRPEfg9t3oDlwzm3WTAv0p83vceqCuxvRo/+N7hXbmtaO7WMGCMvJx0xyIuUDS4NgaEK31oMR9FnX9JNcEQQ==
+vscode-typescript-languageservice@0.32.0:
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/vscode-typescript-languageservice/-/vscode-typescript-languageservice-0.32.0.tgz#6911c77ee966a9c4c5ddd7939267735627adce2c"
+  integrity sha512-RdFJKbQcN6FQ3Vpx3ggM7XJpTDmmMG3MTAJy+IHn9RpuoQLF8z8gKpTsLAJeiPKXi1WTJjHnl1PT+ndNA3ujig==
   dependencies:
-    "@volar/shared" "0.31.4"
+    "@volar/shared" "0.32.0"
     semver "^7.3.5"
     upath "^2.0.1"
     vscode-languageserver-protocol "^3.17.0-next.12"
@@ -3583,27 +3592,22 @@ vscode-uri@^2.1.2:
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.1.2.tgz#c8d40de93eb57af31f3c715dd650e2ca2c096f1c"
   integrity sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==
 
-vscode-uri@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.2.tgz#ecfd1d066cb8ef4c3a208decdbab9a8c23d055d0"
-  integrity sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA==
-
-vscode-uri@^3.0.3:
+vscode-uri@^3.0.2, vscode-uri@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.3.tgz#a95c1ce2e6f41b7549f86279d19f47951e4f4d84"
   integrity sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA==
 
-vscode-vue-languageservice@0.31.4:
-  version "0.31.4"
-  resolved "https://registry.yarnpkg.com/vscode-vue-languageservice/-/vscode-vue-languageservice-0.31.4.tgz#ad4fd65e9ed7d8bb6f14cd4e235cb3969b3055f9"
-  integrity sha512-Pyvtj5iokBilGDH8KY6bocJh8NcIGoFmUksPOOZKBb+4usEHTBtWw/uoH4hjxWwLszMRQuStkXLMaSKtBIv3gQ==
+vscode-vue-languageservice@0.32.0:
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/vscode-vue-languageservice/-/vscode-vue-languageservice-0.32.0.tgz#926fb67b5b083181bde715ef7b160a1a0704c126"
+  integrity sha512-D9mOE6mCH7uZ9RpXVJBWXi32R/9bcpZmfhJwxbHzXlU8oBowY36qtbiZJoI/rcXTF0tB51MXmHeLsXhAi52HVA==
   dependencies:
-    "@volar/code-gen" "0.31.4"
-    "@volar/html2pug" "0.31.4"
-    "@volar/shared" "0.31.4"
-    "@volar/source-map" "0.31.4"
-    "@volar/transforms" "0.31.4"
-    "@volar/vue-code-gen" "0.31.4"
+    "@volar/code-gen" "0.32.0"
+    "@volar/html2pug" "0.32.0"
+    "@volar/shared" "0.32.0"
+    "@volar/source-map" "0.32.0"
+    "@volar/transforms" "0.32.0"
+    "@volar/vue-code-gen" "0.32.0"
     "@vscode/emmet-helper" "^2.8.3"
     "@vue/reactivity" "^3.2.27"
     "@vue/shared" "^3.2.27"
@@ -3613,8 +3617,8 @@ vscode-vue-languageservice@0.31.4:
     vscode-json-languageservice "^4.1.10"
     vscode-languageserver-protocol "^3.17.0-next.12"
     vscode-languageserver-textdocument "^1.0.3"
-    vscode-pug-languageservice "0.31.4"
-    vscode-typescript-languageservice "0.31.4"
+    vscode-pug-languageservice "0.32.0"
+    vscode-typescript-languageservice "0.32.0"
 
 which@^1.2.9:
   version "1.3.1"


### PR DESCRIPTION
## MEMO

- ported the function of `shared.getWorkspaceTypescriptPath`
  - Error when using `shared.getWorkspaceTypescriptPath` of `@volar/shared` v0.32.0 in `coc-volar`.