### PR TITLE
feat: add volar.fix.diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -238,6 +238,11 @@
           "default": false,
           "description": "Enable fix patch for `css` completion issue"
         },
+        "volar.fix.diagnostics": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable fix patch for diagnostics issue"
+        },
         "vetur.enable": {
           "type": "boolean",
           "default": true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,9 @@ import {
   CompletionContext,
   CompletionItem,
   CompletionList,
+  Diagnostic,
   ExtensionContext,
+  HandleDiagnosticsSignature,
   LanguageClient,
   LanguageClientOptions,
   LinesTextDocument,
@@ -69,6 +71,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
             ? handleProvideCompletionItem
             : undefined
           : undefined,
+        handleDiagnostics: getConfigFixDiagnostics() ? handleDiagnostics : undefined,
       },
     };
 
@@ -95,8 +98,18 @@ function getConfigMaxMemory() {
   return workspace.getConfiguration('volar').get<number | null>('maxMemory');
 }
 
+function getConfigFixDiagnostics() {
+  return workspace.getConfiguration('volar').get<boolean>('fix.diagnostics', true);
+}
+
 function getConfigFixCompletion() {
   return workspace.getConfiguration('volar').get<boolean>('fix.completion', true);
+}
+
+function handleDiagnostics(uri: string, diagnostics: Diagnostic[], next: HandleDiagnosticsSignature) {
+  // TODO: remove duplicate diagnostics message in Take Over Mode.
+  // diagnostics.filter(...)
+  next(uri, diagnostics);
 }
 
 // issue: https://github.com/yaegassy/coc-volar/issues/38


### PR DESCRIPTION
Duplicate diagnostic messages in ts files when using "Take Over Mode". Maybe it's a language server side problem, but I'll consider addressing it on the client side.

I will now proceed with verification and implementation.