### PR TITLE
refactor: volar.maxMemory -> volar.vueserver.maxOldSpaceSize

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,11 @@ Check the README of `coc-prettier` for details. <https://github.com/neoclide/coc
 - `volar.diagnostics.enable`: Enable/disable the Volar diagnostics, default: `true`
 - `volar.inlayHints.enable`: Whether to show inlay hints. In order for inlayHints to work with volar, you will need to further configure `typescript.inlayHints.*` or `javascript.inlayHints.*` settings, default: `true`
 - `volar.diagnostics.tsLocale`: Locale of diagnostics messages from typescript, valid option: `["cs", "de", "es", "fr", "it", "ja", "ko", "en", "pl", "pt-br", "ru", "tr", "zh-cn", "zh-tw"]`, default: `"en"`
-- `volar.maxMemory`: Maximum memory (in MB) that the server should use. On some systems this may only have effect when runtime has been set. Minimum 256.
 - `volar-language-features.trace.server`: Traces the communication between coc.nvim and the language server, valid option: `["off", "messages", "verbose"]`, default: `"off"`
 - `volar-language-features-2.trace.server`: Traces the communication between coc.nvim and the language server, valid option: `["off", "messages", "verbose"]`, default: `"off"`
 - `volar-document-features.trace.server`: Traces the communication between coc.nvim and the language server, valid option: `["off", "messages", "verbose"]`, default: `"off"`
 - `volar.vueserver.useSecondServer`: Use second server to progress heavy diagnostic works, the main server workhorse computing intellisense, operations such as auto-complete can respond faster. Note that this will lead to more memory usage, default: `true`
+- `volar.vueserver.maxOldSpaceSize`: Set `--max-old-space-size` option on server process. Maximum memory (in MB) that the server should use. On some systems this may only have effect when runtime has been set. Minimum 256.
 - `volar.takeOverMode.enabled`: Take over language support for *.ts, default: `false`
 - `volar.codeLens.references`: [references] code lens, default: `true`
 - `volar.codeLens.pugTools`: [pug ☐] code lens, default: `false`

--- a/package.json
+++ b/package.json
@@ -150,10 +150,6 @@
           "default": true,
           "description": "Whether to show inlay hints. In order for inlay hints to work with volar, you will need to further configure `typescript.inlayHints.*` or `javascript.inlayHints.*` settings."
         },
-        "volar.maxMemory": {
-          "type": "number",
-          "description": "Maximum memory (in MB) that the server should use. On some systems this may only have effect when runtime has been set. Minimum 256."
-        },
         "volar-language-features.trace.server": {
           "scope": "window",
           "type": "string",
@@ -191,6 +187,14 @@
           "type": "boolean",
           "default": true,
           "description": "Use second server to progress heavy diagnostic works, the main server workhorse computing intellisense, operations such as auto-complete can respond faster. Note that this will lead to more memory usage."
+        },
+        "volar.vueserver.maxOldSpaceSize": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "default": null,
+          "description": "Set `--max-old-space-size` option on server process. Maximum memory (in MB) that the server should use. On some systems this may only have effect when runtime has been set. Minimum 256"
         },
         "volar.codeLens.references": {
           "type": "boolean",

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,9 +36,9 @@ export async function activate(context: ExtensionContext): Promise<void> {
       },
     };
 
-    const memory = Math.floor(Number(getConfigMaxMemory()));
-    if (memory && memory >= 256) {
-      const maxOldSpaceSize = '--max-old-space-size=' + memory.toString();
+    const memorySize = Math.floor(Number(getConfigServerMaxOldSpaceSize()));
+    if (memorySize && memorySize >= 256) {
+      const maxOldSpaceSize = '--max-old-space-size=' + memorySize.toString();
       serverOptions.run.options = { execArgv: [maxOldSpaceSize] };
       if (serverOptions.debug.options) {
         if (serverOptions.debug.options.execArgv) {
@@ -75,6 +75,6 @@ function getConfigDevServerPath() {
   return workspace.getConfiguration('volar').get<string>('dev.serverPath', '');
 }
 
-function getConfigMaxMemory() {
-  return workspace.getConfiguration('volar').get<number | null>('maxMemory');
+function getConfigServerMaxOldSpaceSize() {
+  return workspace.getConfiguration('volar').get<number | null>('vueserver.maxOldSpaceSize');
 }


### PR DESCRIPTION
`volar.vueserver.maxOldSpaceSize` was added in upstream. <https://github.com/johnsoncodehk/volar/pull/1299>

In coc-volar, a setting called `volar.maxMemory` was previously added for the same purpose. <https://github.com/yaegassy/coc-volar/pull/73>

Change from `volar.maxMemory` to `volar.vueserver.maxOldSpaceSize`.

