### PR TITLE
feat: "volar.progressOnInitialization.enable" configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,9 @@ Check the README of `coc-prettier` for details. <https://github.com/neoclide/coc
 - `volar.useWorkspaceTsdk`: Use workspace (project) detected tsLibs in volar. if false, use coc-volar's built-in tsLibs, default: `false`
 - `volar.scaffoldSnippets.enable`: Enable/disable scaffold snippets completion. Typing `vue` or `vuedc` will output completion suggestions. This snippets completion feature will only work on the first line of the file, default: `true`
 - `volar.diagnostics.enable`: Enable/disable the Volar diagnostics, default: `true`
-- `volar.inlayHints.enable`: Whether to show inlay hints. In order for inlayHints to work with volar, you will need to further configure `typescript.inlayHints.*` or `javascript.inlayHints.*` settings, default: `true`
 - `volar.diagnostics.tsLocale`: Locale of diagnostics messages from typescript, valid option: `["cs", "de", "es", "fr", "it", "ja", "ko", "en", "pl", "pt-br", "ru", "tr", "zh-cn", "zh-tw"]`, default: `"en"`
+- `volar.inlayHints.enable`: Whether to show inlay hints. In order for inlayHints to work with volar, you will need to further configure `typescript.inlayHints.*` or `javascript.inlayHints.*` settings, default: `true`
+- `volar.progressOnInitialization.enable`: Enable/disable progress window at language server startup, default: `true`
 - `volar-language-features.trace.server`: Traces the communication between coc.nvim and the language server, valid option: `["off", "messages", "verbose"]`, default: `"off"`
 - `volar-language-features-2.trace.server`: Traces the communication between coc.nvim and the language server, valid option: `["off", "messages", "verbose"]`, default: `"off"`
 - `volar-document-features.trace.server`: Traces the communication between coc.nvim and the language server, valid option: `["off", "messages", "verbose"]`, default: `"off"`

--- a/package.json
+++ b/package.json
@@ -150,6 +150,11 @@
           "default": true,
           "description": "Whether to show inlay hints. In order for inlay hints to work with volar, you will need to further configure `typescript.inlayHints.*` or `javascript.inlayHints.*` settings."
         },
+        "volar.progressOnInitialization.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable/disable progress window at language server startup."
+        },
         "volar-language-features.trace.server": {
           "scope": "window",
           "type": "string",

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     const clientOptions: LanguageClientOptions = {
       documentSelector,
       initializationOptions: initOptions,
-      progressOnInitialization: true,
+      progressOnInitialization: getConfigProgressOnInitialization(),
       synchronize: {
         fileEvents: workspace.createFileSystemWatcher('{**/*.vue,**/*.js,**/*.jsx,**/*.ts,**/*.tsx,**/*.json}'),
       },
@@ -69,6 +69,10 @@ export function deactivate(): Thenable<any> | undefined {
 
 function getConfigVolarEnable() {
   return workspace.getConfiguration('volar').get<boolean>('enable', true);
+}
+
+function getConfigProgressOnInitialization() {
+  return workspace.getConfiguration('volar').get<boolean>('progressOnInitialization.enable', true);
 }
 
 function getConfigDevServerPath() {


### PR DESCRIPTION
There was a recent change in the notification-related features of `coc.nvim`. In `coc-volar`, a progress window is displayed when the language server is started.

https://user-images.githubusercontent.com/188642/172113068-b6a3ec2c-2993-47c3-9b2c-9e4cd3d65aa7.mp4

There seems to be a request to hide this progress window for coc.nvim itself and each coc.nvim extension.

Added a configuration at `coc-volar`.
