### PR TITLE
feat: VitePress support

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Check the README of `coc-prettier` for details. <https://github.com/neoclide/coc
 - `volar.diagnostics.enable`: Enable/disable the Volar diagnostics, default: `true`
 - `volar.diagnostics.tsLocale`: Locale of diagnostics messages from typescript, valid option: `["cs", "de", "es", "fr", "it", "ja", "ko", "en", "pl", "pt-br", "ru", "tr", "zh-cn", "zh-tw"]`, default: `"en"`
 - `volar.inlayHints.enable`: Whether to show inlay hints. In order for inlayHints to work with volar, you will need to further configure `typescript.inlayHints.*` or `javascript.inlayHints.*` settings, default: `true`
+- `volar.vitePressSupport.enable`: Use `.md` instead of `.vue` for file extension. If you use this setting, it is recommended to enable it at the workspace (project) level, default: `false`
 - `volar.progressOnInitialization.enable`: Enable/disable progress window at language server startup, default: `true`
 - `volar-language-features.trace.server`: Traces the communication between coc.nvim and the language server, valid option: `["off", "messages", "verbose"]`, default: `"off"`
 - `volar-language-features-2.trace.server`: Traces the communication between coc.nvim and the language server, valid option: `["off", "messages", "verbose"]`, default: `"off"`

--- a/package.json
+++ b/package.json
@@ -151,6 +151,11 @@
           "default": true,
           "description": "Whether to show inlay hints. In order for inlay hints to work with volar, you will need to further configure `typescript.inlayHints.*` or `javascript.inlayHints.*` settings."
         },
+        "volar.vitePressSupport.enable": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use `.md` instead of `.vue` for file extension. If you use this setting, it is recommended to enable it at the workspace (project) level."
+        },
         "volar.progressOnInitialization.enable": {
           "type": "boolean",
           "default": true,

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "activationEvents": [
     "onLanguage:vue",
+    "onLanguage:markdown",
     "onLanguage:javascript",
     "onLanguage:typescript",
     "onLanguage:javascriptreact",

--- a/src/common.ts
+++ b/src/common.ts
@@ -49,6 +49,13 @@ export async function activate(context: ExtensionContext, createLc: CreateLangua
       activated = true;
     }
 
+    if (workspace.getConfiguration('volar').get<boolean>('vitePressSupport.enable', false)) {
+      if (!activated && document.languageId === 'markdown') {
+        doActivate(context, createLc);
+        activated = true;
+      }
+    }
+
     if (
       !activated &&
       ['javascript', 'typescript', 'javascriptreact', 'typescriptreact'].includes(document.languageId)
@@ -75,6 +82,13 @@ export async function activate(context: ExtensionContext, createLc: CreateLangua
         activated = true;
       }
 
+      if (workspace.getConfiguration('volar').get<boolean>('vitePressSupport.enable', false)) {
+        if (!activated && document.languageId === 'markdown') {
+          doActivate(context, createLc);
+          activated = true;
+        }
+      }
+
       if (
         !activated &&
         ['javascript', 'typescript', 'javascriptreact', 'typescriptreact'].includes(document.languageId)
@@ -95,6 +109,7 @@ export async function doActivate(context: ExtensionContext, createLc: CreateLang
   initializeWorkspaceState(context);
 
   const takeOverMode = takeOverModeEnabled();
+  const isVitePressSupport = workspace.getConfiguration('volar').get<boolean>('vitePressSupport.enable', false);
 
   const languageFeaturesDocumentSelector: DocumentSelector = takeOverMode
     ? [
@@ -106,6 +121,8 @@ export async function doActivate(context: ExtensionContext, createLc: CreateLang
         { scheme: 'file', language: 'json' },
       ]
     : [{ scheme: 'file', language: 'vue' }];
+  if (isVitePressSupport) languageFeaturesDocumentSelector.push({ scheme: 'file', language: 'markdown' });
+
   const documentFeaturesDocumentSelector: DocumentSelector = takeOverMode
     ? [
         { language: 'vue' },
@@ -115,6 +132,7 @@ export async function doActivate(context: ExtensionContext, createLc: CreateLang
         { language: 'typescriptreact' },
       ]
     : [{ language: 'vue' }];
+  if (isVitePressSupport) documentFeaturesDocumentSelector.push({ scheme: 'file', language: 'markdown' });
 
   const _useSecondServer = useSecondServer();
 

--- a/src/features/autoInsertion.ts
+++ b/src/features/autoInsertion.ts
@@ -19,6 +19,7 @@ export async function activate(context: ExtensionContext, htmlClient: LanguageCl
 
   const supportedLanguages: Record<string, boolean> = {
     vue: true,
+    markdown: true,
     javascript: true,
     typescript: true,
     javascriptreact: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,12 +47,17 @@ export async function activate(context: ExtensionContext): Promise<void> {
       }
     }
 
+    let watcherGlobPattern = '{**/*.vue,**/*.js,**/*.jsx,**/*.ts,**/*.tsx,**/*.json}';
+    if (workspace.getConfiguration('volar').get<boolean>('vitePressSupport.enable', false)) {
+      watcherGlobPattern = '{**/*.vue,**/*.md,**/*.js,**/*.jsx,**/*.ts,**/*.tsx,**/*.json}';
+    }
+
     const clientOptions: LanguageClientOptions = {
       documentSelector,
       initializationOptions: initOptions,
       progressOnInitialization: getConfigProgressOnInitialization(),
       synchronize: {
-        fileEvents: workspace.createFileSystemWatcher('{**/*.vue,**/*.js,**/*.jsx,**/*.ts,**/*.tsx,**/*.json}'),
+        fileEvents: workspace.createFileSystemWatcher(watcherGlobPattern),
       },
     };
 


### PR DESCRIPTION
`coc-volar` provide a setting `volar.vitePressSupport.enable` (default: `false`).

If you want to use `.md` instead of `.vue` file in "VitePress", please enable this setting at the workspace (project) level.

**.vim/coc-settings.json**:

```jsonc
{
  "volar.vitePressSupport.enable": true
}
```