### PR TITLE
feat: petite-vue support

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Check the README of `coc-prettier` for details. <https://github.com/neoclide/coc
 - `volar.diagnostics.tsLocale`: Locale of diagnostics messages from typescript, valid option: `["cs", "de", "es", "fr", "it", "ja", "ko", "en", "pl", "pt-br", "ru", "tr", "zh-cn", "zh-tw"]`, default: `"en"`
 - `volar.inlayHints.enable`: Whether to show inlay hints. In order for inlayHints to work with volar, you will need to further configure `typescript.inlayHints.*` or `javascript.inlayHints.*` settings, default: `true`
 - `volar.vitePressSupport.enable`: Use `.md` instead of `.vue` for file extension. If you use this setting, it is recommended to enable it at the workspace (project) level, default: `false`
+- `volar.petiteVueSupport.enable`: Use `.html` instead of `.vue` for file extension. If you use this setting, it is recommended to enable it at the workspace (project) level. You must also place `tsconfig.json` or `jsconfig.json` in your project, default: `false`
 - `volar.progressOnInitialization.enable`: Enable/disable progress window at language server startup, default: `true`
 - `volar-language-features.trace.server`: Traces the communication between coc.nvim and the language server, valid option: `["off", "messages", "verbose"]`, default: `"off"`
 - `volar-language-features-2.trace.server`: Traces the communication between coc.nvim and the language server, valid option: `["off", "messages", "verbose"]`, default: `"off"`

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "activationEvents": [
     "onLanguage:vue",
     "onLanguage:markdown",
+    "onLanguage:html",
     "onLanguage:javascript",
     "onLanguage:typescript",
     "onLanguage:javascriptreact",
@@ -155,6 +156,11 @@
           "type": "boolean",
           "default": false,
           "description": "Use `.md` instead of `.vue` for file extension. If you use this setting, it is recommended to enable it at the workspace (project) level."
+        },
+        "volar.petiteVueSupport.enable": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use `.html` instead of `.vue` for file extension. If you use this setting, it is recommended to enable it at the workspace (project) level. You must also place `tsconfig.json` or `jsconfig.json` in your project."
         },
         "volar.progressOnInitialization.enable": {
           "type": "boolean",

--- a/src/client/statusBar.ts
+++ b/src/client/statusBar.ts
@@ -32,8 +32,21 @@ export async function register(context: ExtensionContext, languageClient: Langua
       statusBar.text = 'Volar (TakeOverMode)';
       statusBar.show();
     } else if (
+      workspace.getConfiguration('volar').get<boolean>('takeOverMode.enabled') &&
+      workspace.getConfiguration('volar').get<boolean>('petiteVueSupport.enable') &&
+      ['html'].includes(document.languageId)
+    ) {
+      statusBar.text = 'Volar (TakeOverMode)';
+      statusBar.show();
+    } else if (
       workspace.getConfiguration('volar').get<boolean>('vitePressSupport.enable') &&
       ['markdown'].includes(document.languageId)
+    ) {
+      statusBar.text = 'Volar';
+      statusBar.show();
+    } else if (
+      workspace.getConfiguration('volar').get<boolean>('petiteVueSupport.enable') &&
+      ['html'].includes(document.languageId)
     ) {
       statusBar.text = 'Volar';
       statusBar.show();

--- a/src/common.ts
+++ b/src/common.ts
@@ -47,8 +47,15 @@ export async function activate(context: ExtensionContext, createLc: CreateLangua
       activated = true;
     }
 
-    if (workspace.getConfiguration('volar').get<boolean>('vitePressSupport.enable', false)) {
-      if (!activated && document.languageId === 'markdown') {
+    if (!activated && document.languageId === 'markdown') {
+      if (workspace.getConfiguration('volar').get<boolean>('vitePressSupport.enable', false)) {
+        doActivate(context, createLc);
+        activated = true;
+      }
+    }
+
+    if (!activated && document.languageId === 'html') {
+      if (workspace.getConfiguration('volar').get<boolean>('petiteVueSupport.enable', false)) {
         doActivate(context, createLc);
         activated = true;
       }
@@ -80,8 +87,15 @@ export async function activate(context: ExtensionContext, createLc: CreateLangua
         activated = true;
       }
 
-      if (workspace.getConfiguration('volar').get<boolean>('vitePressSupport.enable', false)) {
-        if (!activated && document.languageId === 'markdown') {
+      if (!activated && document.languageId === 'markdown') {
+        if (workspace.getConfiguration('volar').get<boolean>('vitePressSupport.enable', false)) {
+          doActivate(context, createLc);
+          activated = true;
+        }
+      }
+
+      if (!activated && document.languageId === 'html') {
+        if (workspace.getConfiguration('volar').get<boolean>('petiteVueSupport.enable', false)) {
           doActivate(context, createLc);
           activated = true;
         }
@@ -108,6 +122,7 @@ export async function doActivate(context: ExtensionContext, createLc: CreateLang
 
   const takeOverMode = takeOverModeEnabled();
   const isVitePressSupport = workspace.getConfiguration('volar').get<boolean>('vitePressSupport.enable', false);
+  const isPetiteVueSupport = workspace.getConfiguration('volar').get<boolean>('petiteVueSupport.enable', false);
 
   const languageFeaturesDocumentSelector: DocumentSelector = takeOverMode
     ? [
@@ -120,6 +135,7 @@ export async function doActivate(context: ExtensionContext, createLc: CreateLang
       ]
     : [{ scheme: 'file', language: 'vue' }];
   if (isVitePressSupport) languageFeaturesDocumentSelector.push({ scheme: 'file', language: 'markdown' });
+  if (isPetiteVueSupport) languageFeaturesDocumentSelector.push({ scheme: 'file', language: 'html' });
 
   const documentFeaturesDocumentSelector: DocumentSelector = takeOverMode
     ? [
@@ -131,6 +147,7 @@ export async function doActivate(context: ExtensionContext, createLc: CreateLang
       ]
     : [{ language: 'vue' }];
   if (isVitePressSupport) documentFeaturesDocumentSelector.push({ scheme: 'file', language: 'markdown' });
+  if (isPetiteVueSupport) documentFeaturesDocumentSelector.push({ scheme: 'file', language: 'html' });
 
   const _useSecondServer = useSecondServer();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,10 +47,14 @@ export async function activate(context: ExtensionContext): Promise<void> {
       }
     }
 
-    let watcherGlobPattern = '{**/*.vue,**/*.js,**/*.jsx,**/*.ts,**/*.tsx,**/*.json}';
+    const globPatterns: string[] = ['**/*.vue', '**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx', '**/*.json'];
     if (workspace.getConfiguration('volar').get<boolean>('vitePressSupport.enable', false)) {
-      watcherGlobPattern = '{**/*.vue,**/*.md,**/*.js,**/*.jsx,**/*.ts,**/*.tsx,**/*.json}';
+      globPatterns.push('**/*.md');
     }
+    if (workspace.getConfiguration('volar').get<boolean>('volar.petiteVueSupport.enable', false)) {
+      globPatterns.push('**/*.html');
+    }
+    const watcherGlobPattern = '{' + globPatterns.join(',') + '}';
 
     const clientOptions: LanguageClientOptions = {
       documentSelector,


### PR DESCRIPTION
`coc-volar` provide a setting `volar.petiteVueSupport.enable` (default: `false`).

If you want to use .html instead of .vue extension in "petite-vue", please enable this setting at the workspace (project) level.

You must also place `tsconfig.json` or `jsconfig.json` in your project.

**.vim/coc-settings.json**:

```jsonc
{
  "volar.petiteVueSupport.enable": true 
}
```