### PR TITLE
refactor: add middleware for adjusting code-action

### DIFF
--- a/package.json
+++ b/package.json
@@ -349,6 +349,11 @@
           "default": "",
           "description": "(For develop and check) Custom path to volar server module, ~ and $HOME, etc. can also be used. If there is no setting, the built-in module will be used "
         },
+        "volar.middleware.provideCodeActions.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable fix patch for code action issue #112, #134"
+        },
         "vetur.enable": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
## Description

Close #112 #134

I found a way to adjust Code Action on the client (coc-volar) side. Adjusted a problem that caused an error when executing Code Action and prevented it from being executed.

There are other issues related to code-action. volar's langauge sever also lists code-actions that are not executable in the current context.

I have tried to prevent non-executable actions from appearing in the list.

## DEMO (mp4)

https://user-images.githubusercontent.com/188642/174920783-5ce862fe-b102-4950-a285-0080344c44d9.mp4
