### PR TITLE
refactor(middleware): remove only processing related to document version in codeaction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,17 +3,13 @@ import {
   CodeAction,
   CodeActionContext,
   Command,
-  CreateFile,
-  DeleteFile,
   ExtensionContext,
   LanguageClient,
   LanguageClientOptions,
   LinesTextDocument,
   ProvideCodeActionsSignature,
   Range,
-  RenameFile,
   ServerOptions,
-  TextDocumentEdit,
   Thenable,
   TransportKind,
   workspace,
@@ -110,41 +106,6 @@ async function handleProvideCodeActions(
       // volar's langauge sever also lists code-actions that are not executable in the current context.
       // code-action with the "disabled" property are excludes from the new code-action list.
       continue;
-    } else if ('edit' in originalAction) {
-      if (originalAction.edit && originalAction.edit.documentChanges) {
-        const newDocumentChanges: (TextDocumentEdit | CreateFile | RenameFile | DeleteFile)[] = [];
-
-        for (const documentChange of originalAction.edit.documentChanges) {
-          if ('textDocument' in documentChange) {
-            const newTextDocumentEdit: TextDocumentEdit = {
-              textDocument: {
-                uri: documentChange.textDocument.uri,
-                version: 0,
-              },
-              edits: documentChange.edits,
-            };
-            newDocumentChanges.push(newTextDocumentEdit);
-          } else {
-            newDocumentChanges.push(documentChange);
-          }
-        }
-
-        const newAction: CodeAction = {
-          title: originalAction.title,
-          kind: originalAction.kind ?? originalAction.kind,
-          diagnostics: originalAction.diagnostics ?? originalAction.diagnostics,
-          isPreferred: originalAction.isPreferred ?? originalAction.isPreferred,
-          edit: {
-            changes: originalAction.edit.changes ?? originalAction.edit.changes,
-            documentChanges: newDocumentChanges,
-          },
-          command: originalAction.command ?? originalAction.command,
-          clientId: originalAction.clientId ?? originalAction.clientId,
-        };
-        newActions.push(newAction);
-      } else {
-        newActions.push(originalAction);
-      }
     } else {
       newActions.push(originalAction);
     }


### PR DESCRIPTION
## Description

There was a commit to correct the problem on the language server side.

- https://github.com/johnsoncodehk/volar/commit/6791d8b786fb3941b803b69b5d76c63ada5f6ca3

Only middleware processes related to the document version were removed

## Releated Issues

- <https://github.com/yaegassy/coc-volar/issues/112>
- <https://github.com/yaegassy/coc-volar/issues/134>
- <https://github.com/johnsoncodehk/volar/issues/1490>