### PR TITLE
refactor(inlay-hints): use languages.registerInlayHintsProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -402,7 +402,6 @@
   "dependencies": {
     "@volar/shared": "0.38.5",
     "@volar/vue-language-server": "0.38.5",
-    "typescript": "4.7.3",
-    "vscode-languageserver-types": "^3.17.0-next.9"
+    "typescript": "4.7.3"
   }
 }

--- a/src/features/inlayHints.ts
+++ b/src/features/inlayHints.ts
@@ -1,16 +1,31 @@
-import { commands, Disposable, Document, events, ExtensionContext, LanguageClient, Range, workspace } from 'coc.nvim';
-import { InlayHint } from 'vscode-languageserver-types';
-
-const supportLanguages = ['vue', 'javascript', 'typescript', 'javascriptreact', 'typescriptreact'];
+import {
+  commands,
+  DocumentSelector,
+  Emitter,
+  Event,
+  ExtensionContext,
+  InlayHint,
+  InlayHintsProvider,
+  LanguageClient,
+  languages,
+  Range,
+  TextDocument,
+  workspace,
+} from 'coc.nvim';
 
 export async function register(context: ExtensionContext, languageClient: LanguageClient) {
   await languageClient.onReady();
 
-  await workspace.nvim.command('hi default link CocVolarTypeHint CocHintSign');
+  const documentSelector: DocumentSelector = [
+    { scheme: 'file', language: 'vue' },
+    { scheme: 'file', language: 'javascript' },
+    { scheme: 'file', language: 'typescript' },
+    { scheme: 'file', language: 'javascriptreact' },
+    { scheme: 'file', language: 'typescriptreact' },
+  ];
   const inlayHintsProvider = new VolarInlayHintsProvider(context, languageClient);
-  inlayHintsProvider.activate();
-  context.subscriptions.push(inlayHintsProvider);
 
+  context.subscriptions.push(languages.registerInlayHintsProvider(documentSelector, inlayHintsProvider));
   context.subscriptions.push(
     commands.registerCommand('volar.toggleInlayHints', async () => {
       await inlayHintsProvider.toggle();
@@ -18,113 +33,55 @@ export async function register(context: ExtensionContext, languageClient: Langua
   );
 }
 
-export class VolarInlayHintsProvider implements Disposable {
-  private readonly disposables: Disposable[] = [];
-  private inlayHintsNS = workspace.createNameSpace('volar-inlay-hint');
+export class VolarInlayHintsProvider implements InlayHintsProvider {
+  private readonly _onDidChangeInlayHints = new Emitter<void>();
+  public readonly onDidChangeInlayHints: Event<void> = this._onDidChangeInlayHints.event;
+
   private inlayHintsEnabled: boolean;
-  private _inlayHints: Map<string, InlayHint[]> = new Map();
-  private _context: ExtensionContext;
-  private _client: LanguageClient;
+  private context: ExtensionContext;
+  private client: LanguageClient;
 
   constructor(context: ExtensionContext, client: LanguageClient) {
-    this._context = context;
-    this._client = client;
+    this.context = context;
+    this.client = client;
     this.inlayHintsEnabled = !!workspace.getConfiguration('volar').get<boolean>('inlayHints.enable');
   }
 
-  dispose() {
-    this.disposables.forEach((d) => d.dispose());
-    this._inlayHints.clear();
-  }
+  async provideInlayHints(document: TextDocument, range: Range) {
+    const inlayHints: InlayHint[] = [];
+    if (!this.inlayHintsEnabled) return [];
 
-  async activate() {
-    events.on('InsertLeave', async (bufnr) => {
-      const doc = workspace.getDocument(bufnr);
-      if (doc && supportLanguages.includes(doc.languageId)) {
-        this.syncAndRenderHints(doc);
-      }
+    const response: InlayHint[] = await this.client.sendRequest('textDocument/inlayHint', {
+      textDocument: { uri: document.uri },
+      range,
+    });
+    if (!response) return [];
+
+    response.forEach((r) => {
+      const hint: InlayHint = {
+        label: r.label,
+        position: r.position,
+        kind: r.kind ?? r.kind,
+        paddingLeft: r.paddingLeft ? r.paddingLeft : undefined,
+        paddingRight: r.paddingRight ? r.paddingRight : undefined,
+        textEdits: r.textEdits ? r.textEdits : undefined,
+        tooltip: r.tooltip ? r.tooltip : undefined,
+        data: r.data ? r.data : undefined,
+      };
+
+      inlayHints.push(hint);
     });
 
-    workspace.onDidChangeTextDocument(
-      (e) => {
-        const doc = workspace.getDocument(e.bufnr);
-        if (doc && supportLanguages.includes(doc.languageId)) {
-          if (events.insertMode) {
-            return;
-          }
-          this.syncAndRenderHints(doc);
-        }
-      },
-      this,
-      this.disposables
-    );
-
-    workspace.onDidOpenTextDocument(
-      (e) => {
-        if (e && supportLanguages.includes(e.languageId)) {
-          const doc = workspace.getDocument(e.uri);
-          this.syncAndRenderHints(doc);
-        }
-      },
-      this,
-      this.disposables
-    );
-
-    const current = await workspace.document;
-    if (supportLanguages.includes(current.languageId)) {
-      this.syncAndRenderHints(current);
-    }
+    return inlayHints;
   }
 
   async toggle() {
     if (this.inlayHintsEnabled) {
       this.inlayHintsEnabled = false;
-
-      const doc = await workspace.document;
-      if (!doc) return;
-
-      doc.buffer.clearNamespace(this.inlayHintsNS);
+      this._onDidChangeInlayHints.fire();
     } else {
       this.inlayHintsEnabled = true;
-      await this.activate();
+      this._onDidChangeInlayHints.fire();
     }
-  }
-
-  private async syncAndRenderHints(doc: Document) {
-    if (!this.inlayHintsEnabled) return;
-    if (doc && supportLanguages.includes(doc.languageId)) {
-      this.fetchHints(doc).then(async (hints) => {
-        if (!hints) return;
-        this.renderHints(doc, hints);
-      });
-    }
-  }
-
-  private async fetchHints(doc: Document): Promise<null | InlayHint[]> {
-    const endLine = doc.lineCount - 1;
-    const endChar = doc.getline(endLine).length;
-    const range = Range.create(0, 0, doc.lineCount - 1, endChar);
-    const param = { range, textDocument: { uri: doc.uri.toString() } };
-    return this._client.sendRequest<InlayHint[] | null>('textDocument/inlayHint', param);
-  }
-
-  private async renderHints(doc: Document, hints: InlayHint[]) {
-    this._inlayHints.set(doc.uri, hints);
-
-    const chaining_hints = {};
-    for (const item of hints) {
-      const chunks: [[string, string]] = [[item.label.toString(), 'CocVolarTypeHint']];
-      if (chaining_hints[item.position.line] === undefined) {
-        chaining_hints[item.position.line] = chunks;
-      } else {
-        chaining_hints[item.position.line].push([' ', 'Normal']);
-        chaining_hints[item.position.line].push(chunks[0]);
-      }
-    }
-
-    doc.buffer.clearNamespace(this.inlayHintsNS);
-    Object.keys(chaining_hints).forEach(async (line) => {
-      await doc.buffer.setVirtualText(this.inlayHintsNS, Number(line), chaining_hints[line], {});
-    });
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,11 +1718,6 @@ vscode-languageserver-types@3.17.1, vscode-languageserver-types@^3.15.1, vscode-
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz#c2d87fa7784f8cac389deb3ff1e2d9a7bef07e16"
   integrity sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ==
 
-vscode-languageserver-types@^3.17.0-next.9:
-  version "3.17.0-next.10"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.0-next.10.tgz#90c8b901eab67c4a63de05e3dae6e38d050fa12f"
-  integrity sha512-BbuWVFKgkGX/VgbVPSofxZx2wqR5DMC+3IiB6FgJ7250GiLIKa5Z7RXaQ7i8z4t9rHEmpTA3UbrRkoLPjQUf6Q==
-
 vscode-languageserver@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-8.0.1.tgz#56bd7a01f5c88af075a77f1d220edcb30fc4bdc7"


### PR DESCRIPTION
## Description

The current coc-volar implementation of inlay hints uses a wrapper around the neovim api.

A feature for inlay hints was added in coc.nvim itself about 2 months ago.

- <https://github.com/neoclide/coc.nvim/commit/3a26df0abc7d432cca7a0ee6b8da3fc1ea5cae42>

I knew this feature had been added, but I had to wait for the passage of time to be able to use it unless I was using the relatively new coc.nvim.

## Note & Memo

As an additional note, on the `feat/3.17` branch of coc.nvim, if the Language Server supports inlay hints, inlay hints can be used without implementation on the extension side.

- <https://github.com/neoclide/coc.nvim/tree/feat/3.17>
- <https://github.com/neoclide/coc.nvim/commit/c69db06a4f1629ed7881f9a2d3be516d502fe699>

