### PR TITLE
refactor: setting language via `InitializeParams.locale` instead of `__language`

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -218,6 +218,9 @@ export function processMd() {
 
 function getFillInitializeParams(featuresKinds: LanguageFeaturesKind[]) {
   return function (params: InitializeParams) {
+
+    (params as any).locale = workspace.getConfiguration('volar').get<string>('tsLocale', 'en');
+
     if (params.capabilities.textDocument) {
       if (!featuresKinds.includes(LanguageFeaturesKind.Semantic)) {
         params.capabilities.textDocument.references = undefined;
@@ -284,7 +287,6 @@ function getInitializationOptions(serverMode: ServerMode, context: ExtensionCont
     vitePress: {
       processMdFile: processMd(),
     },
-    __language: workspace.getConfiguration('volar').get<string>('tsLocale', 'en'),
   };
   return initializationOptions;
 }


### PR DESCRIPTION
`__language` a hack add for VSCode and I wanted to remove it in VSCode by same way with this PR, I'm not sure `(params as any).locale` can pass to language server successfully, please let me know the this way not working.