### PR TITLE
feat: add middleware for adjusting "@" prefix completion candidates

### DIFF
--- a/package.json
+++ b/package.json
@@ -436,6 +436,11 @@
           "default": true,
           "description": "Enable fix patch for code action issue #112, #134"
         },
+        "volar.middleware.provideCompletionItem.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable fix patch for code action issue #226"
+        },
         "vetur.enable": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
An update to coc.nvim itself caused a problem with `@` prefix completion.

- <https://github.com/yaegassy/coc-volar/issues/226>
- <https://github.com/neoclide/coc.nvim/issues/4348>

This problem has now been adjusted in coc.nvim itself, but it would be better to deal with the filtering of candidates on the extension side.

Add middleware to adjust completion feature.
