### PR TITLE
chore: change volar.middleware.provideCompletionItem.enable default to false

### DIFF
--- a/package.json
+++ b/package.json
@@ -438,7 +438,7 @@
         },
         "volar.middleware.provideCompletionItem.enable": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Enable fix patch for code action issue #226"
         },
         "vetur.enable": {


### PR DESCRIPTION
It seems that there was a commit on the coc.nvim side that will adjust the problem of filtering completion candidates.

- <https://github.com/neoclide/coc.nvim/commit/7817ea6718d824b5715196982dda99265146c32a>

Change the setting to disable by default any middleware added on the extension side.