### PR TITLE
Remove volar.vueserver.json.customBlockSchemaUrls setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ autocmd Filetype vue setlocal iskeyword+=-
 - `volar.vueserver.maxFileSize`: Maximum file size for Vue Server to load. (default: 20MB), default: `20971520`
 - `volar.vueserver.petiteVue.processHtmlFile`: Use `.html` instead of `.vue` for file extension. If you use this setting, it is recommended to enable it at the workspace (project) level. You must also place `tsconfig.json` or `jsconfig.json` in your project, default: `false`
 - `volar.vueserver.vitePress.processMdFile`: Use `.md` instead of `.vue` for file extension. If you use this setting, it is recommended to enable it at the workspace (project) level. You must also place `tsconfig.json` or `jsconfig.json` in your project, default: `false`
-- `volar.vueserver.json.customBlockSchemaUrls`: preset json schema urls for custom blocks, default: `null`
 - `volar.vueserver.textDocumentSync`: Defines how the host (editor) should sync document changes to the language server. SFC incremental parser only working when config "incremental", valid option: `["incremental", "full", "none"]`, default: `incremental`
 - `volar.vueserver.diagnosticModel`: Diagnostic update model, valid option: `["push", "pull"]`, default: `push`
 - `volar.vueserver.maxOldSpaceSize`: Set `--max-old-space-size` option on server process. Maximum memory (in MB) that the server should use. On some systems this may only have effect when runtime has been set. Minimum 256.

--- a/package.json
+++ b/package.json
@@ -264,11 +264,6 @@
           "default": false,
           "description": "Use `.md` instead of `.vue` for file extension. If you use this setting, it is recommended to enable it at the workspace (project) level. You must also place `tsconfig.json` or `jsconfig.json` in your project."
         },
-        "volar.vueserver.json.customBlockSchemaUrls": {
-          "type": "object",
-          "default": null,
-          "description": "preset json schema urls for custom blocks"
-        },
         "volar.vueserver.textDocumentSync": {
           "type": "string",
           "default": "incremental",

--- a/src/common.ts
+++ b/src/common.ts
@@ -323,11 +323,6 @@ function getInitializationOptions(serverMode: ServerMode, context: ExtensionCont
     vitePress: {
       processMdFile: processMd(),
     },
-    json: {
-      customBlockSchemaUrls: workspace
-        .getConfiguration('volar')
-        .get<Record<string, string>>('vueserver.json.customBlockSchemaUrls'),
-    },
     additionalExtensions: additionalExtensions(),
     fullCompletionList: fullCompletionList(),
   };


### PR DESCRIPTION
Since the following diagnostics message is output when editing a jsonc format file (e.g. `tscofnig.json`, `coc-settings.json`, etc...), coc-volar removes the `volar.vueserver.json.customBlockSchemaUrls` setting itself.

For example, a error against commenting out.

**Diagnostics Message**:

```
[vue-semantic-server 521] Comments are not permitted in JSON. [E]
```

<img width="936" alt="remove-json-customBlockSchemaUrls" src="https://user-images.githubusercontent.com/188642/220006775-41002be5-fe33-4eea-9658-6a17859ecf33.png">
