### PR TITLE
Sync volar v1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ Notes for make `VitePress`, `petite-vue` project working with Volar.
 
 ### VitePress
 
-- Set `volar.vueserver.vitePress.processMdFile` to `true` in `.vim/coc-settings.json`.
+- Set `vue.server.vitePress.supportMdFile` to `true` in `.vim/coc-settings.json`.
   - **[WARNING]** If you use this setting, it is recommended to enable it at the workspace (project) level.
 - `vue` is optional add in devDependencies for better intellisense.
 - Make sure added related `.md` files path to tsconfig.json `include` property.
 
 ### petite-vue
 
-- Set `volar.vueserver.petiteVue.processHtmlFile` to `true` in `.vim/coc-settings.json`.
+- Set `vue.server.petiteVue.supportHtmlFile` to `true` in `.vim/coc-settings.json`.
   - **[WARNING]** If you use this setting, it is recommended to enable it at the workspace (project) level.
 - Set `html.enable` to `false` in `.vim/coc-settings.json`.
 - `vue` is optional add in devDependencies for better intellisense.
@@ -107,29 +107,30 @@ autocmd Filetype vue setlocal iskeyword+=-
 - `volar.disableFormatting`: Disable formatting from Volar, default: `false`
 - `volar.disableProgressNotifications`: Disable the initialization and workdone progress notifications, default: `false`
 - `volar.dev.serverPath`: (For develop and check) Custom path to volar server module, `~` and `$HOME`, etc. can also be used. If there is no setting, the built-in module will be used, default: `""`
+- `volar.takeOverMode.enabled`: Take over language support for `*.ts`, default: `false`
+- `volar.format.initialIndent`: Whether to have initial indent, default: `{}`
 - `vue-semantic-server.trace.server`: Traces the communication between coc.nvim and the language server, valid option: `["off", "messages", "verbose"]`, default: `"off"`
 - `vue-syntactic-server.trace.server`: Traces the communication between coc.nvim and the language server, valid option: `["off", "messages", "verbose"]`, default: `"off"`
-- `volar.vueserver.configFilePath`: Path to volar.config.js, default: `./volar.config.js`
-- `volar.vueserver.maxFileSize`: Maximum file size for Vue Server to load. (default: 20MB), default: `20971520`
-- `volar.vueserver.petiteVue.processHtmlFile`: Recognize `.html` extension as PetiteVue file format. If you use this setting, it is recommended to enable it at the workspace (project) level. You must also place `tsconfig.json` or `jsconfig.json` in your project, and adding `__PATH_TO_HTML_FILES_/*.html` to config include option, default: `false`
-- `volar.vueserver.vitePress.processMdFile`: Recognize `.md` extension as VitePress file format. If you use this setting, it is recommended to enable it at the workspace (project) level. You must also place `tsconfig.json` or `jsconfig.json` in your project, and adding `__PATH_TO_MD_FILES_/*.md` to config include option, default: `false`
-- `volar.vueserver.diagnosticModel`: Diagnostic update model, valid option: `["push", "pull"]`, default: `push`
-- `volar.vueserver.maxOldSpaceSize`: Set `--max-old-space-size` option on server process. Maximum memory (in MB) that the server should use. On some systems this may only have effect when runtime has been set. Minimum 256.
-- `volar.vueserver.reverseConfigFilePriority`: Reverse priority for tsconfig pickup, default: `false`
-- `volar.vueserver.additionalExtensions`: List any additional file extensions that should be processed as Vue files (requires restart), default: `[]`
-- `volar.vueserver.fullCompletionList`: Enable this option if you want to get complete CompletionList in language client. (Disable for better performance), default: `false`
-- `volar.takeOverMode.enabled`: Take over language support for `*.ts`, default: `false`
-- `volar.format.initialIndent`: Whether to have initial indent, default: `{ "html": true }`
-- `vue.features.codeActions.enable`: Enabled code actions, default: `true`
-- `vue.features.codeLens.enable`: Enabled code lens, default: `true`
-- `vue.features.complete.tagNameCasing`: Preferred tag name case, valid options: `["autoKebab", "autoPascal", "kebab", "pascal"]`, default: `"autoPascal"`
-- `vue.features.complete.propNameCasing`: Preferred attr name case, valid options: `["autoKebab", "autoCamel", "kebab", "camel"]`, default: `"autoKebab"`
-- `vue.features.complete.normalizeComponentImportName`: Normalize import name for auto import. (\"myCompVue\" -> \"MyComp\"), default: `true`
-- `vue.features.autoInsert.parentheses`: Auto-wrap `()` to As Expression in interpolations for fix volar-issue #520, default: `true`
-- `vue.features.autoInsert.dotValue`: Auto-complete Ref value with `.value`, default: `false`
-- `vue.features.autoInsert.bracketSpacing`: Auto add space between double curly brackets: `{{|}} -> {{ | }}`, default: `true`
-- `vue.features.inlayHints.missingProps`: Show inlay hints for missing required props, `false`
-- `vue.features.inlayHints.inlineHandlerLeading`: Show inlay hints for event argument in inline handlers, default: `false`
+- `vue.server.configFilePath`: Path to volar.config.js, default: `./volar.config.js`
+- `vue.server.maxFileSize`: Maximum file size for Vue Server to load. (default: 20MB), default: `20971520`
+- `vue.server.petiteVue.supportHtmlFile `: Recognize `.html` extension as PetiteVue file format. If you use this setting, it is recommended to enable it at the workspace (project) level. You must also place `tsconfig.json` or `jsconfig.json` in your project, and adding `__PATH_TO_HTML_FILES_/*.html` to config include option, default: `false`
+- `vue.server.vitePress.supportMdFile`: Recognize `.md` extension as VitePress file format. If you use this setting, it is recommended to enable it at the workspace (project) level. You must also place `tsconfig.json` or `jsconfig.json` in your project, and adding `__PATH_TO_MD_FILES_/*.md` to config include option, default: `false`
+- `vue.server.diagnosticModel`: Diagnostic update model, valid option: `["push", "pull"]`, default: `push`
+- `vue.server.maxOldSpaceSize`: Set `--max-old-space-size` option on server process. Maximum memory (in MB) that the server should use. On some systems this may only have effect when runtime has been set. Minimum 256.
+- `vue.server.reverseConfigFilePriority`: Reverse priority for tsconfig pickup, default: `false`
+- `vue.server.additionalExtensions`: List any additional file extensions that should be processed as Vue files (requires restart), default: `[]`
+- `vue.server.fullCompletionList`: Enable this option if you want to get complete CompletionList in language client. (Disable for better performance), default: `false`
+- `vue.codeActions.enabled`: Enabled code actions, default: `true`
+- `vue.codeLens.enabled`: Enabled code lens, default: `true`
+- `vue.complete.casing.tags`: Preferred tag name case, valid options: `["autoKebab", "autoPascal", "kebab", "pascal"]`, default: `"autoPascal"`
+- `vue.complete.casing.props`: Preferred attr name case, valid options: `["autoKebab", "autoCamel", "kebab", "camel"]`, default: `"autoKebab"`
+- `vue.complete.normalizeComponentImportName`: Normalize import name for auto import. (\"myCompVue\" -> \"MyComp\"), default: `true`
+- `vue.autoInsert.parentheses`: Auto-wrap `()` to As Expression in interpolations for fix volar-issue #520, default: `true`
+- `vue.autoInsert.dotValue`: Auto-complete Ref value with `.value`, default: `false`
+- `vue.autoInsert.bracketSpacing`: Auto add space between double curly brackets: `{{|}} -> {{ | }}`, default: `true`
+- `vue.inlayHints.missingProps`: Show inlay hints for missing required props, `false`
+- `vue.inlayHints.inlineHandlerLeading`: Show inlay hints for event argument in inline handlers, default: `false`
+- `vue.inlayHints.optionsWrapper`: Show inlay hints for component options wrapper for type support, default: `true`
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -248,87 +248,6 @@
           "default": false,
           "description": "Enable fix patch for code action issue #226"
         },
-        "vue-semantic-server.trace.server": {
-          "scope": "window",
-          "type": "string",
-          "enum": [
-            "off",
-            "messages",
-            "verbose"
-          ],
-          "default": "off",
-          "description": "Traces the communication between coc.nvim and the language server."
-        },
-        "vue-syntactic-server.trace.server": {
-          "scope": "window",
-          "type": "string",
-          "enum": [
-            "off",
-            "messages",
-            "verbose"
-          ],
-          "default": "off",
-          "description": "Traces the communication between coc.nvim and the language server."
-        },
-        "volar.vueserver.configFilePath": {
-          "type": "string",
-          "default": "./volar.config.js",
-          "description": "Path to volar.config.js."
-        },
-        "volar.vueserver.maxFileSize": {
-          "type": "number",
-          "default": 20971520,
-          "description": "Maximum file size for Vue Server to load. (default: 20MB)"
-        },
-        "volar.vueserver.petiteVue.processHtmlFile": {
-          "type": "boolean",
-          "default": false,
-          "description": "Recognize `.html` extension as PetiteVue file format. If you use this setting, it is recommended to enable it at the workspace (project) level. You must also place `tsconfig.json` or `jsconfig.json` in your project, and adding `__PATH_TO_HTML_FILES_/*.html` to config include option"
-        },
-        "volar.vueserver.vitePress.processMdFile": {
-          "type": "boolean",
-          "default": false,
-          "description": "Recognize `.md` extension as VitePress file format. If you use this setting, it is recommended to enable it at the workspace (project) level. You must also place `tsconfig.json` or `jsconfig.json` in your project, and adding `__PATH_TO_MD_FILES_/*.md` to config include option"
-        },
-        "volar.vueserver.diagnosticModel": {
-          "type": "string",
-          "default": "push",
-          "enum": [
-            "push",
-            "pull"
-          ],
-          "enumDescriptions": [
-            "Diagnostic push by language server.",
-            "Diagnostic pull by language client."
-          ],
-          "description": "Diagnostic update model."
-        },
-        "volar.vueserver.maxOldSpaceSize": {
-          "type": [
-            "number",
-            "null"
-          ],
-          "default": null,
-          "description": "Set `--max-old-space-size` option on server process. Maximum memory (in MB) that the server should use. On some systems this may only have effect when runtime has been set. Minimum 256"
-        },
-        "volar.vueserver.reverseConfigFilePriority": {
-          "type": "boolean",
-          "default": false,
-          "description": "Reverse priority for tsconfig pickup."
-        },
-        "volar.vueserver.additionalExtensions": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [],
-          "description": "List any additional file extensions that should be processed as Vue files (requires restart)."
-        },
-        "volar.vueserver.fullCompletionList": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enable this option if you want to get complete CompletionList in language client. (Disable for better performance)"
-        },
         "volar.takeOverMode.enabled": {
           "type": "boolean",
           "default": false,
@@ -395,17 +314,98 @@
             }
           }
         },
-        "vue.features.codeActions.enable": {
+        "vue-semantic-server.trace.server": {
+          "scope": "window",
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "Traces the communication between coc.nvim and the language server."
+        },
+        "vue-syntactic-server.trace.server": {
+          "scope": "window",
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "Traces the communication between coc.nvim and the language server."
+        },
+        "vue.server.configFilePath": {
+          "type": "string",
+          "default": "./volar.config.js",
+          "description": "Path to volar.config.js."
+        },
+        "vue.server.maxFileSize": {
+          "type": "number",
+          "default": 20971520,
+          "description": "Maximum file size for Vue Server to load. (default: 20MB)"
+        },
+        "vue.server.petiteVue.supportHtmlFile": {
+          "type": "boolean",
+          "default": false,
+          "description": "Recognize `.html` extension as PetiteVue file format. If you use this setting, it is recommended to enable it at the workspace (project) level. You must also place `tsconfig.json` or `jsconfig.json` in your project, and adding `__PATH_TO_HTML_FILES_/*.html` to config include option"
+        },
+        "vue.server.vitePress.supportMdFile": {
+          "type": "boolean",
+          "default": false,
+          "description": "Recognize `.md` extension as VitePress file format. If you use this setting, it is recommended to enable it at the workspace (project) level. You must also place `tsconfig.json` or `jsconfig.json` in your project, and adding `__PATH_TO_MD_FILES_/*.md` to config include option"
+        },
+        "vue.server.diagnosticModel": {
+          "type": "string",
+          "default": "push",
+          "enum": [
+            "push",
+            "pull"
+          ],
+          "enumDescriptions": [
+            "Diagnostic push by language server.",
+            "Diagnostic pull by language client."
+          ],
+          "description": "Diagnostic update model."
+        },
+        "vue.server.maxOldSpaceSize": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "default": null,
+          "description": "Set `--max-old-space-size` option on server process. Maximum memory (in MB) that the server should use. On some systems this may only have effect when runtime has been set. Minimum 256"
+        },
+        "vue.server.reverseConfigFilePriority": {
+          "type": "boolean",
+          "default": false,
+          "description": "Reverse priority for tsconfig pickup."
+        },
+        "vue.server.additionalExtensions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "List any additional file extensions that should be processed as Vue files (requires restart)."
+        },
+        "vue.server.fullCompletionList": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable this option if you want to get complete CompletionList in language client. (Disable for better performance)"
+        },
+        "vue.codeActions.enabled": {
           "type": "boolean",
           "default": true,
           "description": "Enabled code actions."
         },
-        "vue.features.codeLens.enable": {
+        "vue.codeLens.enabled": {
           "type": "boolean",
           "default": true,
           "description": "Enabled code lens."
         },
-        "vue.features.complete.tagNameCasing": {
+        "vue.complete.casing.tags": {
           "type": "string",
           "enum": [
             "autoKebab",
@@ -422,7 +422,7 @@
           "default": "autoPascal",
           "description": "Preferred tag name case."
         },
-        "vue.features.complete.propNameCasing": {
+        "vue.complete.casing.props": {
           "type": "string",
           "enum": [
             "autoKebab",
@@ -439,35 +439,40 @@
           "default": "autoKebab",
           "description": "Preferred attr name case."
         },
-        "vue.features.complete.normalizeComponentImportName": {
+        "vue.complete.normalizeComponentImportName": {
           "type": "boolean",
           "default": true,
           "description": "Normalize import name for auto import. (\"myCompVue\" -> \"MyComp\")"
         },
-        "vue.features.autoInsert.parentheses": {
+        "vue.autoInsert.parentheses": {
           "type": "boolean",
           "default": true,
           "description": "Auto-wrap `()` to As Expression in interpolations for fix volar-issue #520."
         },
-        "vue.features.autoInsert.dotValue": {
+        "vue.autoInsert.dotValue": {
           "type": "boolean",
           "default": false,
           "description": "Auto-complete Ref value with `.value`."
         },
-        "vue.features.autoInsert.bracketSpacing": {
+        "vue.autoInsert.bracketSpacing": {
           "type": "boolean",
           "default": true,
           "description": "Auto add space between double curly brackets: `{{|}} -> {{ | }}`"
         },
-        "vue.features.inlayHints.missingProps": {
+        "vue.inlayHints.missingProps": {
           "type": "boolean",
           "default": false,
           "description": "Show inlay hints for missing required props."
         },
-        "vue.features.inlayHints.inlineHandlerLeading": {
+        "vue.inlayHints.inlineHandlerLeading": {
           "type": "boolean",
           "default": false,
           "description": "Show inlay hints for event argument in inline handlers."
+        },
+        "vue.inlayHints.optionsWrapper": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show inlay hints for component options wrapper for type support."
         },
         "vetur.enable": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -520,7 +520,7 @@
     ]
   },
   "dependencies": {
-    "@volar/vue-language-server": "1.5.4",
+    "@volar/vue-language-server": "1.6.0",
     "typescript": "5.0.4"
   }
 }

--- a/src/client/commands/doctor.ts
+++ b/src/client/commands/doctor.ts
@@ -91,7 +91,7 @@ function doctorCommand(context: ExtensionContext) {
       vueTscVersion: vueTscVersion === undefined ? 'none' : vueTscVersion,
       tsVersion,
       tsdkPath,
-      settings: workspace.getConfiguration('volar'),
+      settings: { volar: { ...workspace.getConfiguration('volar') }, vue: { ...workspace.getConfiguration('vue') } },
     };
 
     const outputText = JSON.stringify(doctorData, null, 2);

--- a/src/common.ts
+++ b/src/common.ts
@@ -51,8 +51,8 @@ export async function activate(context: ExtensionContext, createLc: CreateLangua
     }
 
     if (
-      (!activated && currentLangId === 'markdown' && config.vueserver.vitePress.processMdFile) ||
-      (!activated && currentLangId === 'html' && config.vueserver.petiteVue.processHtmlFile)
+      (!activated && currentLangId === 'markdown' && config.server.vitePress.supportMdFile) ||
+      (!activated && currentLangId === 'html' && config.server.petiteVue.supportHtmlFile)
     ) {
       doActivate(context, createLc);
       activated = true;
@@ -86,8 +86,8 @@ export async function activate(context: ExtensionContext, createLc: CreateLangua
       }
 
       if (
-        (!activated && currentlangId === 'markdown' && config.vueserver.vitePress.processMdFile) ||
-        (!activated && currentlangId === 'html' && config.vueserver.petiteVue.processHtmlFile)
+        (!activated && currentlangId === 'markdown' && config.server.vitePress.supportMdFile) ||
+        (!activated && currentlangId === 'html' && config.server.petiteVue.supportHtmlFile)
       ) {
         doActivate(context, createLc);
         activated = true;
@@ -147,7 +147,7 @@ export async function doActivate(context: ExtensionContext, createLc: CreateLang
     if (
       workspace.getConfiguration('volar').get<boolean>('autoCreateQuotes') ||
       workspace.getConfiguration('volar').get<boolean>('autoClosingTags') ||
-      workspace.getConfiguration('vue').get<boolean>('features.autoInsert.dotValue')
+      workspace.getConfiguration('vue').get<boolean>('autoInsert.dotValue')
     ) {
       autoInsertion.register(context, syntacticClient, semanticClient);
     }
@@ -193,18 +193,14 @@ export function getDocumentSelector(_context: ExtensionContext, serverMode: Serv
     }
   }
 
-  if (config.vueserver.petiteVue.processHtmlFile) {
+  if (config.server.petiteVue.supportHtmlFile) {
     selectors.push({ language: 'html' });
   }
-  if (config.vueserver.vitePress.processMdFile) {
+  if (config.server.vitePress.supportMdFile) {
     selectors.push({ language: 'markdown' });
   }
 
   return selectors;
-}
-
-export function diagnosticModel() {
-  return workspace.getConfiguration('volar').get<'push' | 'pull'>('vueserver.diagnosticModel');
 }
 
 async function getInitializationOptions(serverMode: ServerMode, context: ExtensionContext) {
@@ -215,21 +211,23 @@ async function getInitializationOptions(serverMode: ServerMode, context: Extensi
 
   const initializationOptions: VueServerInitializationOptions = {
     // volar
-    configFilePath: config.vueserver.configFilePath,
+    configFilePath: config.server.configFilePath,
     serverMode,
-    diagnosticModel: config.vueserver.diagnosticModel === 'pull' ? DiagnosticModel.Pull : DiagnosticModel.Push,
+    diagnosticModel: config.server.diagnosticModel === 'pull' ? DiagnosticModel.Pull : DiagnosticModel.Push,
     typescript: resolveCurrentTsPaths,
-    reverseConfigFilePriority: config.vueserver.reverseConfigFilePriority,
-    maxFileSize: config.vueserver.maxFileSize,
-    fullCompletionList: config.vueserver.fullCompletionList,
+    reverseConfigFilePriority: config.server.reverseConfigFilePriority,
+    maxFileSize: config.server.maxFileSize,
+    semanticTokensLegend: {
+      tokenTypes: ['component'],
+      tokenModifiers: [],
+    },
+    fullCompletionList: config.server.fullCompletionList,
     // vue
-    petiteVue: {
-      processHtmlFile: !!config.vueserver.petiteVue.processHtmlFile,
-    },
-    vitePress: {
-      processMdFile: !!config.vueserver.vitePress.processMdFile,
-    },
-    additionalExtensions: config.vueserver.additionalExtensions,
+    additionalExtensions: [
+      ...config.server.additionalExtensions,
+      ...(!config.server.petiteVue.supportHtmlFile ? [] : ['html']),
+      ...(!config.server.vitePress.supportMdFile ? [] : ['md']),
+    ],
   };
   return initializationOptions;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,93 +1,65 @@
 import { workspace } from 'coc.nvim';
 
-const volarConfigs = () => workspace.getConfiguration('volar');
-const vueConfigs = () => workspace.getConfiguration('vue');
+const _config = () => workspace.getConfiguration('vue');
 
 export const config = {
-  //splitEditors: {
-  //  get layout() {
-  //    return volarConfigs().get<{ left: string[]; right: string[] }>('splitEditors.layout') ?? { left: [], right: [] };
-  //  },
+  //update: (section: string, value: any) => _config().update(section, value),
+  //get splitEditors(): Readonly<{
+  //  icon: boolean;
+  //  layout: { left: string[]; right: string[] };
+  //}> {
+  //  return _config().get('splitEditors')!;
   //},
-  features: {
-    updateImportsOnFileMove: {
-      get enable() {
-        return vueConfigs().get<boolean>('features.updateImportsOnFileMove.enable');
-      },
-    },
-    codeActions: {
-      get enable() {
-        return vueConfigs().get<boolean>('features.codeActions.enable');
-      },
-      set enable(value) {
-        vueConfigs().update('features.codeActions.enable', value);
-      },
-      get savingTimeLimit() {
-        return vueConfigs().get<number>('features.codeActions.savingTimeLimit') ?? -1;
-      },
-    },
-    codeLens: {
-      get enable() {
-        return vueConfigs().get<boolean>('features.codeLens.enable');
-      },
-    },
-    complete: {
-      get attrNameCasing() {
-        return vueConfigs().get<'autoKebab' | 'autoCamel' | 'kebab' | 'camel'>('features.complete.propNameCasing');
-      },
-      get tagNameCasing() {
-        return vueConfigs().get<'autoKebab' | 'autoPascal' | 'kebab' | 'pascal'>('features.complete.tagNameCasing');
-      },
-    },
-  },
-  json: {
-    get customBlockSchemaUrls() {
-      return volarConfigs().get<Record<string, string>>('json.customBlockSchemaUrls');
-    },
-  },
-  vueserver: {
-    get maxOldSpaceSize() {
-      return volarConfigs().get<number>('vueserver.maxOldSpaceSize');
-    },
-    get maxFileSize() {
-      return volarConfigs().get<number>('vueserver.maxFileSize');
-    },
-    get reverseConfigFilePriority() {
-      return volarConfigs().get<boolean>('vueserver.reverseConfigFilePriority');
-    },
-    get diagnosticModel() {
-      return volarConfigs().get<'push' | 'pull'>('vueserver.diagnosticModel');
-    },
-    get additionalExtensions() {
-      return volarConfigs().get<string[]>('vueserver.additionalExtensions') ?? [];
-    },
-    get fullCompletionList() {
-      return volarConfigs().get<boolean>('vueserver.fullCompletionList');
-    },
-    get configFilePath() {
-      return volarConfigs().get<string>('vueserver.configFilePath');
-    },
-    petiteVue: {
-      get processHtmlFile() {
-        return volarConfigs().get<boolean>('vueserver.petiteVue.processHtmlFile');
-      },
-    },
+  //get doctor(): Readonly<{
+  //  status: boolean;
+  //}> {
+  //  return _config().get('doctor')!;
+  //},
+  get server(): Readonly<{
+    maxOldSpaceSize: number;
+    maxFileSize: number;
+    reverseConfigFilePriority: boolean;
+    diagnosticModel: 'push' | 'pull';
+    additionalExtensions: string[];
+    fullCompletionList: boolean;
+    configFilePath: string;
     vitePress: {
-      get processMdFile() {
-        return volarConfigs().get<boolean>('vueserver.vitePress.processMdFile');
-      },
-    },
+      supportMdFile: boolean;
+    };
+    petiteVue: {
+      supportHtmlFile: boolean;
+    };
+    //json: {
+    //  customBlockSchemaUrls: Record<string, string>;
+    //};
+  }> {
+    return _config().get('server')!;
   },
-  //doctor: {
-  //  get status() {
-  //    return volarConfigs().get<boolean>('doctor.status');
-  //  },
+  //get updateImportsOnFileMove(): Readonly<{
+  //  enabled: boolean;
+  //}> {
+  //  return _config().get('updateImportsOnFileMove')!;
   //},
-  //nameCasing: {
-  //  get status() {
-  //    return volarConfigs().get<boolean>('nameCasing.status');
-  //  },
-  //},
+  get codeActions(): Readonly<{
+    enabled: boolean;
+    savingTimeLimit: number;
+  }> {
+    return _config().get('codeActions')!;
+  },
+  get codeLens(): Readonly<{
+    enabled: boolean;
+  }> {
+    return _config().get('codeLens')!;
+  },
+  get complete(): Readonly<{
+    casing: {
+      status: boolean;
+      props: 'autoKebab' | 'autoCamel' | 'kebab' | 'camel';
+      tags: 'autoKebab' | 'autoPascal' | 'kebab' | 'pascal';
+    };
+  }> {
+    return _config().get('complete')!;
+  },
 };
 
 //
@@ -125,10 +97,10 @@ export function getDisabledFeatures() {
     disabledFeatures.push('documentFormatting');
     disabledFeatures.push('documentRangeFormatting');
   }
-  if (!config.features.codeActions.enable) {
+  if (!config.codeActions.enabled) {
     disabledFeatures.push('codeAction');
   }
-  if (!config.features.codeLens.enable) {
+  if (!config.codeLens.enabled) {
     disabledFeatures.push('codeLens');
   }
   if (getConfigDisableProgressNotifications()) {

--- a/src/features/autoInsertion.ts
+++ b/src/features/autoInsertion.ts
@@ -169,14 +169,14 @@ export async function register(context: ExtensionContext, htmlClient: LanguageCl
           if (document.uri === activeDocument.uri && activeDocument.version === version) {
             if (typeof text === 'string') {
               if (lastChange.text === '>') {
-                // autoClosingTags
+                // volar.autoClosingTags
                 snippetManager.insertSnippet(text, true, Range.create(position, position));
               } else if (lastChange.text === '=') {
-                // autoCreateQuotes
+                // volar.autoCreateQuotes
                 snippetManager.insertSnippet(text, true, Range.create(position, position));
               } else {
-                // vue.features.autoInsert.dotValue
-                if (workspace.getConfiguration('vue').get<boolean>('features.autoInsert.dotValue')) {
+                // vue.autoInsert.dotValue
+                if (workspace.getConfiguration('vue').get<boolean>('autoInsert.dotValue')) {
                   snippetManager.insertSnippet(text, true, Range.create(position, position));
                 }
               }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import {
   getDisabledFeatures,
   getConfigMiddlewareProvideCodeActionsEnable,
   getConfigMiddlewareProvideCompletionItemEnable,
+  config,
 } from './config';
 
 let serverModule: string;
@@ -70,7 +71,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
       );
     }
 
-    const maxOldSpaceSize = workspace.getConfiguration('volar').get<number | null>('vueserver.maxOldSpaceSize');
+    const maxOldSpaceSize = config.server.maxOldSpaceSize;
     const runOptions = { execArgv: <string[]>[] };
     if (maxOldSpaceSize) {
       runOptions.execArgv.push('--max-old-space-size=' + maxOldSpaceSize);

--- a/yarn.lock
+++ b/yarn.lock
@@ -448,10 +448,10 @@
   dependencies:
     muggle-string "^0.2.2"
 
-"@volar/vue-language-core@1.5.4":
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/@volar/vue-language-core/-/vue-language-core-1.5.4.tgz#5ba7c705a28f644222f7c741ce6e271242379645"
-  integrity sha512-lTTGwqGDXbj8bFxHatII8sOu4rCUXf8ptcF4MUeMd+Yf40h0yq1BCRrQOVJpqlsJEvNQXNEsSGODrfeNFoJImg==
+"@volar/vue-language-core@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@volar/vue-language-core/-/vue-language-core-1.6.0.tgz#c21c758825c56977f65ab44b0e486587fd017b66"
+  integrity sha512-oyX+A4vclBlDB7UQtfAPraD6tt3nE+y9YNXdH+xjDi//Cokdx65PZnwLaiG+hURI6WgDn1ZQffTE1OeJtr786A==
   dependencies:
     "@volar/language-core" "1.4.1"
     "@volar/source-map" "1.4.1"
@@ -463,22 +463,22 @@
     muggle-string "^0.2.2"
     vue-template-compiler "^2.7.14"
 
-"@volar/vue-language-server@1.5.4":
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/@volar/vue-language-server/-/vue-language-server-1.5.4.tgz#bc116b225967359649ccba9ba30062e650a99fe6"
-  integrity sha512-X60PgzinBq+Sd5ofT/DXGXCup38N/1PGLCmE3Y4wt0/K3UA33BtEzQfXDf0PSxlT0JiwPDiOnaLju0YHtrYiWA==
+"@volar/vue-language-server@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@volar/vue-language-server/-/vue-language-server-1.6.0.tgz#ba48a5dd6cd1419aeccf5ad5568bf02daa77afd6"
+  integrity sha512-KI8ot6bKg21xb2Q4SW8bNvfTEFUZoAZfr++b+pDWlimKSwgzeGZ7Rv8ADfqS9hhGyJsa6d6A0PbtW2FpLOBxYQ==
   dependencies:
     "@volar/language-core" "1.4.1"
     "@volar/language-server" "1.4.1"
-    "@volar/vue-language-core" "1.5.4"
-    "@volar/vue-language-service" "1.5.4"
+    "@volar/vue-language-core" "1.6.0"
+    "@volar/vue-language-service" "1.6.0"
     vscode-languageserver-protocol "^3.17.3"
-    vue-component-meta "1.5.4"
+    vue-component-meta "1.6.0"
 
-"@volar/vue-language-service@1.5.4":
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/@volar/vue-language-service/-/vue-language-service-1.5.4.tgz#69207864e34946e9e2024c973f82ea6213d9f88d"
-  integrity sha512-ipD5pdHIM3ofaJr2B242t4p3/i4xEQ9Bm3gmqNn3VZEgwuEKW7J0D0EnWTDo+gn7RxjEiBUpcPZ+LvlHbTkjkg==
+"@volar/vue-language-service@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@volar/vue-language-service/-/vue-language-service-1.6.0.tgz#86a5705ba902a6f6503a587c2e1f85f0b195fe61"
+  integrity sha512-defSACPmfY2ra2h98cLi7ZEnMKiXkdzBkWTY4ks/xpjKtq1EzFAILMZxyYiVZHJcuCztpzu3dW8cYbdEKpHpqg==
   dependencies:
     "@volar-plugins/css" "2.0.0"
     "@volar-plugins/emmet" "2.0.0"
@@ -491,7 +491,7 @@
     "@volar/language-core" "1.4.1"
     "@volar/language-service" "1.4.1"
     "@volar/source-map" "1.4.1"
-    "@volar/vue-language-core" "1.5.4"
+    "@volar/vue-language-core" "1.6.0"
     "@vue/compiler-dom" "^3.2.0"
     "@vue/reactivity" "^3.2.0"
     "@vue/shared" "^3.2.0"
@@ -1658,20 +1658,20 @@ vscode-uri@^3.0.7:
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.7.tgz#6d19fef387ee6b46c479e5fb00870e15e58c1eb8"
   integrity sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA==
 
-vue-component-meta@1.5.4:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/vue-component-meta/-/vue-component-meta-1.5.4.tgz#e994e1ecb54f92d1484408ea2f573c17142a53e8"
-  integrity sha512-pUdVz5S+JIiKSAGQ2DCDC3yE9NcQ74U6BIN7dBHqNNaHrxTKYGkOWulKMCDPGfaao2sfQppSLjOXwuG+vcj/SQ==
+vue-component-meta@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/vue-component-meta/-/vue-component-meta-1.6.0.tgz#1af336c3140438ebf122600e024dba31ad2fd3bb"
+  integrity sha512-4feEfPe0djJ/MdIKTKxKj01bSb7L7nr0jZtY6qiCK0YTNCVVhqKoP/z2tXfqLYec8tieFLJRzEkQEcQyBBsJ3w==
   dependencies:
     "@volar/language-core" "1.4.1"
-    "@volar/vue-language-core" "1.5.4"
+    "@volar/vue-language-core" "1.6.0"
     typesafe-path "^0.2.2"
-    vue-component-type-helpers "1.5.4"
+    vue-component-type-helpers "1.6.0"
 
-vue-component-type-helpers@1.5.4:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/vue-component-type-helpers/-/vue-component-type-helpers-1.5.4.tgz#dab7e727dce8d73e57e27144549dd65940f41d13"
-  integrity sha512-IkOF3nWXOdNwd7ZhETSu3dswjbnWCpOtvEj/jXs4XcR0GddGtoXzrI7cbBc7sPBuZWakuQN6TSe+9cFn/4tZyg==
+vue-component-type-helpers@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/vue-component-type-helpers/-/vue-component-type-helpers-1.6.0.tgz#1c7080966448b1adc50b69d50b12e6a6ecdebfc3"
+  integrity sha512-+l6AWO3Lhw/WDuIY8VIxbOdxmlztgN2CLwNYRkjqjyo4OZO6GlR6sUi+w4wPr4m53bwV8rO+2xraRL4548PSMQ==
 
 vue-template-compiler@^2.7.14:
   version "2.7.14"


### PR DESCRIPTION
In this update, the names of the various settings have been significantly changed.

**Rename settings**:

- `volar.vueserver.configFilePath` -> `vue.server.configFilePath`
- `volar.vueserver.maxFileSize` -> `vue.server.maxFileSize`
- `volar.vueserver.petiteVue.processHtmlFile` -> `vue.server.petiteVue.supportHtmlFile`
- `volar.vueserver.vitePress.processMdFile` -> `vue.server.vitePress.supportMdFile`
- `volar.vueserver.diagnosticModel` -> `vue.server.diagnosticModel`
- `volar.vueserver.maxOldSpaceSize` -> `vue.server.maxOldSpaceSize`
- `volar.vueserver.reverseConfigFilePriority` -> `vue.server.reverseConfigFilePriority`
- `volar.vueserver.additionalExtensions` -> `vue.server.additionalExtensions`
- `volar.vueserver.fullCompletionList` -> `vue.server.fullCompletionList`
- `vue.features.codeActions.enable` -> `vue.codeActions.enabled`
- `vue.features.codeLens.enable` -> `vue.codeLens.enabled`
- `vue.features.complete.tagNameCasing` -> `vue.complete.casing.tags`
- `vue.features.complete.propNameCasing` -> `vue.complete.casing.props`
- `vue.features.complete.normalizeComponentImportName` -> `vue.complete.normalizeComponentImportName`
- `vue.features.autoInsert.parentheses` -> `vue.autoInsert.parentheses`
- `vue.features.autoInsert.dotValue` -> `vue.autoInsert.dotValue`
- `vue.features.autoInsert.bracketSpacing` -> `vue.autoInsert.bracketSpacing`
- `vue.features.inlayHints.missingProps` -> `vue.inlayHints.missingProps`
- `vue.features.inlayHints.inlineHandlerLeading` -> `vue.inlayHints.inlineHandlerLeading`

**Add settings**:

- `vue.inlayHints.optionsWrapper`

