### PR TITLE
feat: support `vue.autoInsert.bracketSpacing` feature

### DIFF
--- a/src/features/autoInsertion.ts
+++ b/src/features/autoInsertion.ts
@@ -131,9 +131,9 @@ export async function activate(_selectors: DocumentSelector, client: LanguageCli
         },
       };
 
-      const result = await client.sendRequest(AutoInsertRequestType.method, params);
+      const result = await client.sendRequest<TextEdit>(AutoInsertRequestType.method, params);
 
-      if (typeof result === 'string') {
+      if (typeof result === 'string' || typeof result === 'object') {
         return result;
       } else {
         return undefined;


### PR DESCRIPTION
Close https://github.com/yaegassy/coc-volar/issues/328

**Description**:

To enable this feature, you need to have a plugin installed that automatically inserts `}` when you type `{`, such as `jiangmiao/auto-pairs`. By the way, VS Code has this feature built-in by default.

**DEMO (mp4)**:

https://github.com/yaegassy/coc-volar/assets/188642/007d1fe0-0016-4a6c-b70f-f5efc68491b2

